### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/bounce2.cpp
+++ b/bounce2.cpp
@@ -1,4 +1,4 @@
-// Please read Bounce2.h for information about the liscence and authors
+// Please read Bounce2.h for information about the licence and authors
 
 
 #include "bounce2.h"

--- a/bounce2.cpp
+++ b/bounce2.cpp
@@ -72,7 +72,7 @@ bool Bounce::update()
     // If the readState is different from previous readState, reset the debounce timer - as input is still unstable
     // and we want to prevent new button state changes until the previous one has remained stable for the timeout.
     if ( readState != getStateFlag(UNSTABLE_STATE) ) {
-	// Update Unstable Bit to macth readState
+	// Update Unstable Bit to match readState
         toggleStateFlag(UNSTABLE_STATE);
         previous_millis = millis();
     }

--- a/doc/advanced-install.md
+++ b/doc/advanced-install.md
@@ -81,7 +81,7 @@ The adapter works as a capacative touch sensor,
 like a touch lamp.
 
 You might wire these pins to screws or conductive pads. 
-These can be used instead of, or in additon to, the normal pins D0, D1, and D2.
+These can be used instead of, or in addition to, the normal pins D0, D1, and D2.
 
 You do not need a ground wire with capacative touch!
 


### PR DESCRIPTION
Corrected several spelling issues in various files.

### List of modifications:
- `bounce2.cpp`, line 1: `liscence` → `licence`
- `bounce2.cpp`, line 75: `macth` → `match`
- `doc/advanced-install.md`, line 84: `additon` → `addition`

This PR does not modify any logic or behavior.