### PR TITLE
Polish: test channel UX + Micro wiring docs + DIY-only Micro gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ License: MIT
 * See [TRRS_TRINKEY_BUILD.md](TRRS_TRINKEY_BUILD.md) for detailed instructions
 
 # Experimental: Arduino Micro (ATmega32U4)
-* [Arduino Micro](https://store.arduino.cc/products/arduino-micro) — 5V AVR alternative to SAMD21 boards
+* [Arduino Micro](https://store.arduino.cc/products/arduino-micro) — 5V AVR alternative to SAMD21 boards. DIY/breadboard-only; there is no Micro-targeted PCB.
+* **Wiring:** D2 = Dit, D1 = Dah, D0 = Straight Key, D10 = Piezo, GND = ground. Full walkthrough including headphone-jack and optional radio-output wiring → **[doc/advanced-install.md](doc/advanced-install.md#arduino-micro--notes-and-build)**.
 * **Limitations vs. SAMD21:**
   * No capacitive touch (hardware not present on ATmega32U4)
   * No button menu (no resistor ladder support)
   * No LED status indicators
   * CW memory slots shortened: 3 × ~12 seconds (vs. 25 seconds on SAMD21)
   * Radio output on A2/A3 uses 5V logic — check radio tolerance or use a level shifter
-* **Flashing:** uses WebSerial + AVR109 (Caterina bootloader). No UF2 drag-and-drop — flash from [vailadapter.com](https://vailadapter.com) in Chrome/Edge/Opera, or via `arduino-cli upload --fqbn arduino:avr:micro`.
-* See [doc/advanced-install.md](doc/advanced-install.md) for details.
+* **Flashing:** uses WebSerial + AVR109 (Caterina bootloader). No UF2 drag-and-drop — flash from [vailadapter.com](https://vailadapter.com) (activate the 🧪 Test channel, then DIY No PCB → Arduino Micro) in Chrome/Edge/Opera, or via `arduino-cli upload --fqbn arduino:avr:micro`.
 
 # Setting Up
 

--- a/doc/advanced-install.md
+++ b/doc/advanced-install.md
@@ -26,7 +26,9 @@ Then compile and upload the sketch.
 
 ## Arduino Micro — Notes and Build
 
-The Arduino Micro is supported as an experimental target. To build for it:
+The Arduino Micro is supported as an experimental DIY/breadboard-only target (there's no Micro PCB variant). It uses 5V logic instead of the SAMD21's 3.3V, and has a micro-USB connector.
+
+### Build
 
 1. In `config.h`, uncomment `#define ARDUINO_MICRO_BOARD` and comment out all other board configs.
 2. Build with:
@@ -37,21 +39,53 @@ The Arduino Micro is supported as an experimental target. To build for it:
    ```
    arduino-cli upload --fqbn arduino:avr:micro -p <PORT> build_output
    ```
-   …or use the web updater at [vailadapter.com](https://vailadapter.com), which will speak the Caterina/AVR109 protocol via WebSerial.
+   …or use the web updater at [vailadapter.com](https://vailadapter.com) (activate the 🧪 Test channel and pick **DIY No PCB → Arduino Micro** in the wizard — it speaks the Caterina/AVR109 protocol via WebSerial).
 
-### Micro pin map
-* D0: Straight Key
-* D1: Dah
-* D2: Dit
-* D10: Piezo/buzzer
-* A2/A3: optional radio output (uncomment `HAS_RADIO_OUTPUT` in config.h — 5V logic!)
+### Micro pinout & wiring
+
+Full pinout diagram and datasheet: [docs.arduino.cc/hardware/micro](https://docs.arduino.cc/hardware/micro).
+
+Required connections:
+
+| Function | Micro pin | Notes |
+|---|---|---|
+| Ground | `GND` | Common for paddle/key, piezo, radio |
+| Dit (paddle) | `D2` | Tie paddle dit contact to D2, ring it to GND through the switch |
+| Dah (paddle) | `D1` | Same pattern as dit |
+| Straight key | `D0` | For a straight key or mono-TRS jack tip |
+| Piezo buzzer | `D10` → piezo `+`, `GND` → piezo `−` | Passive piezo; polarity doesn't matter for tone |
+| Radio output dit (optional) | `A3` | **5V logic** — verify radio tolerance or use a level shifter/transistor |
+| Radio output dah (optional) | `A2` | Same 5V caveat |
+
+The internal pull-ups are enabled, so each input pin (D0/D1/D2) is HIGH when the contact is open and pulled LOW when the paddle/key closes. No external resistors needed on the paddle side.
+
+### Using a 3.5mm TRS headphone jack (straight key or paddle)
+
+Wire the jack exactly like the XIAO version, using the Micro's equivalent pins:
+
+```
+    o  --- D2  (tip   — dit, or straight-key contact)
+   |_| --- D1  (ring  — dah)
+   | | --- GND (sleeve)
+   | |
+```
+
+For a simple mono straight key, wire only tip (`D0`) and sleeve (`GND`).
+
+### Entering the bootloader
+
+The web updater handles this automatically (1200-baud touch), but if you need to do it manually:
+
+- **Double-tap the reset button** on the Micro within ~1 second. A new COM port will appear for ~8 seconds — that's the Caterina bootloader port.
 
 ### Micro limitations
-* No capacitive touch (ATmega32U4 lacks FreeTouch hardware)
-* No button menu (no resistor ladder implementation for AVR)
-* No LED state indicators
-* CW memory: 3 slots × ~12 seconds each (vs. 25 seconds on SAMD21), due to the 1024-byte EEPROM and 2.5 KB RAM budget
-* Radio output pins are 5V — verify your radio's keying line can accept 5V, or use a transistor/level shifter
+
+* **No capacitive touch** — ATmega32U4 lacks the FreeTouch hardware. All paddle/key inputs must use physical switches.
+* **No button menu** — the resistor-ladder menu is SAMD-only. Change settings via MIDI (vailmorse.com) instead.
+* **No LED status indicators** — the onboard LED is not driven by the firmware (RAM is tight; skipped for the AVR port).
+* **CW memory** — 3 slots × ~12 seconds each (vs. 25 seconds on SAMD21), due to the 1024-byte EEPROM and 2.5 KB RAM budget.
+* **5V radio output** — the optional radio pins swing to 5V, not 3.3V. Verify your radio's keying line can accept 5V, or use a transistor/level shifter.
+* **Flashing** — no UF2 drag-and-drop. Use the web updater's test channel, Arduino IDE, or `arduino-cli upload`.
 
 ## Will Not Work!
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
         <div style="flex: 1 1 auto; min-width: 240px;">
             <strong style="color: #ff8a8a;">🧪 Test channel active</strong>
             <div style="font-size: 13px; margin-top: 4px;">
-                You're downloading <strong>pre-release firmware</strong> from <code style="background: rgba(0,0,0,0.3); padding: 1px 6px; border-radius: 4px;">firmware_files/test/</code>. Build info is available at <a href="firmware_files/test/BUILD_INFO.txt" target="_blank" style="color: #ffb8b8;">BUILD_INFO.txt</a>.
+                You're downloading <strong>pre-release firmware</strong> intended for beta testers. <a href="firmware_files/test/BUILD_INFO.txt" target="_blank" style="color: #ffb8b8;">View build info</a>.
             </div>
         </div>
         <button id="exitTestChannelButton" class="btn-secondary" style="flex: 0 0 auto; padding: 6px 14px; background: #3a1414; border: 1px solid #ff6b6b; color: #ffd8d8; cursor: pointer; border-radius: 6px;">Switch back to stable</button>
@@ -148,7 +148,7 @@
             <div class="selection-card" data-board="micro" id="microCard">
                 <div class="card-icon">🔸</div>
                 <h3>Arduino Micro</h3>
-                <p>ATmega32U4-based. Community/DIY only.</p>
+                <p>ATmega32U4-based. Breadboard / DIY builds only.</p>
                 <div class="hint">⚠️ Experimental: no capacitive touch, no button menu, limited CW memory length. Flashed via WebSerial (not UF2 drag-and-drop).</div>
             </div>
         </div>
@@ -208,7 +208,7 @@
                 <span id="downloadText">Download UF2 File</span>
             </a>
             <div id="step3TestChip" style="display: none; margin-top: 10px; padding: 8px 12px; background: rgba(255, 107, 107, 0.12); border: 1px solid #ff6b6b; border-radius: 6px; color: #ffb0b0; font-size: 13px;">
-                🧪 <strong>Test channel:</strong> this download comes from <code>firmware_files/test/</code>. Click "Switch back to stable" at the top of the page to exit.
+                🧪 <strong>Test channel:</strong> you're about to download a pre-release build. Click "Switch back to stable" at the top of the page to exit.
             </div>
         </div>
 
@@ -323,7 +323,7 @@
             <p>Once the Micro is in bootloader mode (a new serial port will appear for ~8 seconds), click the button below and select that <strong>new</strong> bootloader port. The firmware will be written directly over the serial connection.</p>
             <button id="microFlashButton" class="btn-primary">⚡ Flash Firmware via WebSerial</button>
             <div id="microTestChip" style="display: none; margin-top: 10px; padding: 8px 12px; background: rgba(255, 107, 107, 0.12); border: 1px solid #ff6b6b; border-radius: 6px; color: #ffb0b0; font-size: 13px;">
-                🧪 <strong>Test channel:</strong> firmware will be fetched from <code>firmware_files/test/arduino_micro.hex</code>.
+                🧪 <strong>Test channel:</strong> this will flash a pre-release build.
             </div>
             <div class="progress-container" id="microProgressContainer" style="display: none; margin-top: 16px;">
                 <div class="progress-label" id="microProgressLabel">Preparing…</div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -54,13 +54,18 @@ function applyTestChannelUI() {
     const microChip = document.getElementById('microTestChip');
     if (microChip) microChip.style.display = active ? 'block' : 'none';
 
-    // The Arduino Micro board card is experimental — only surface it when
-    // the user has opted into the test channel. Keeps stable users from
-    // selecting a board that may not have firmware deployed yet.
+    updateMicroCardVisibility();
+}
+
+// The Arduino Micro card is experimental — only show it when the user
+// has opted into the test channel AND picked the DIY No PCB path. Makes
+// sense: there's no PCB version of the adapter designed for Micro, so
+// the Micro is strictly a DIY/breadboard target.
+function updateMicroCardVisibility() {
     const microCard = document.getElementById('microCard');
-    if (microCard) {
-        microCard.style.display = active ? '' : 'none';
-    }
+    if (!microCard) return;
+    const show = isTestChannelActive() && wizardState.model === 'non_pcb';
+    microCard.style.display = show ? '' : 'none';
 }
 
 // Firmware file mapping — URLs go through firmwareUrl() so the test
@@ -178,6 +183,8 @@ function updateStep2Content() {
             qtpyHint.style.display = 'block';
         }
     }
+    // Micro card visibility depends on both test channel and model
+    updateMicroCardVisibility();
 }
 
 function updateProgressBar(stepNumber) {
@@ -672,7 +679,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (nextState) {
             const ok = confirm(
                 '🧪 Enable the test channel?\n\n' +
-                'You will download pre-release firmware from firmware_files/test/ instead of the stable builds. ' +
+                'You will download pre-release firmware intended for beta testers instead of the stable builds. ' +
                 'Test builds may be incomplete or unstable.\n\n' +
                 'You can switch back at any time.'
             );


### PR DESCRIPTION
Follow-ups to #66 based on hands-on testing.

**1. Test channel UX cleanup**
End users shouldn't see internal folder paths. Stripped references to firmware_files/test/ from the confirm dialog, persistent banner, and inline chips. All now just say "pre-release firmware intended for beta testers."

**2. Arduino Micro gated to DIY No PCB only**
There's no Micro-targeted PCB, so the Micro card now only appears when test channel is active AND model = DIY No PCB.

**3. Arduino Micro wiring docs expanded**
Previous docs only listed pin numbers. Now has a full pin-wiring table, TRS headphone-jack diagram adapted for Micro pins, internal-pullup note, manual bootloader-entry procedure, and a link to the official Arduino Micro datasheet. README links directly to the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Polish the Arduino Micro experimental support, improve its documentation and wiring guidance, and refine the test channel UX and visibility of the Micro board in the firmware download wizard.

Enhancements:
- Clarify that Arduino Micro is a DIY/breadboard-only experimental target and expand its advanced install docs with detailed pinout, wiring tables, TRS jack usage, and bootloader instructions.
- Update the README to link directly to the expanded Arduino Micro docs and better describe wiring and flashing paths via the test channel.
- Gate the Arduino Micro selection card so it only appears when the test channel is active and the DIY No PCB model path is selected, matching its DIY-only status.
- Simplify test channel messaging across the UI to describe pre-release, beta-targeted firmware instead of exposing internal folder paths.

Documentation:
- Enhance Arduino Micro documentation with build instructions, wiring diagrams, limitations, and bootloader usage, and cross-link it from the README for easier discovery.