### PR TITLE
summit firmware workflow: install pinned libraries instead of relying on bundled folder

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -18,6 +18,22 @@ on:
           - stable  # → docs/firmware_files/summit/       (production)
           - none    # → build only, artifacts only, no commit
 
+# Pinned to match the local C:\acli build environment documented in the
+# vail-summit project guidelines. Update versions here AND in the local
+# arduino-cli/user/libraries/ so CI and local stay in sync.
+env:
+  ESP32_CORE_VERSION: "2.0.14"
+  LIB_LOVYANGFX: "1.1.16"
+  LIB_LVGL: "8.3.11"
+  LIB_ADAFRUIT_LC709203F: "1.3.4"
+  LIB_ADAFRUIT_BUSIO: "1.17.4"
+  LIB_ADAFRUIT_MAX1704X: "1.0.3"
+  LIB_ARDUINOJSON: "7.0.4"
+  LIB_WEBSOCKETS: "2.4.1"
+  LIB_ESPASYNCWEBSERVER: "3.6.0"
+  LIB_ASYNCTCP: "3.3.2"
+  LIB_NIMBLE_ARDUINO: "1.4.2"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,19 +49,44 @@ jobs:
           fetch-depth: 1
           path: vail-summit
 
-      - name: Build firmware with bundled arduino-cli
-        working-directory: vail-summit/arduino-cli
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Install ESP32 platform (pinned)
         run: |
-          chmod +x ./arduino-cli
-          ./arduino-cli compile \
-            --config-file arduino-cli.yaml \
+          arduino-cli config init --overwrite
+          arduino-cli config add board_manager.additional_urls \
+            https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32@${ESP32_CORE_VERSION}
+
+      - name: Install pinned libraries
+        run: |
+          arduino-cli lib install "LovyanGFX@${LIB_LOVYANGFX}"
+          arduino-cli lib install "lvgl@${LIB_LVGL}"
+          arduino-cli lib install "Adafruit LC709203F@${LIB_ADAFRUIT_LC709203F}"
+          arduino-cli lib install "Adafruit BusIO@${LIB_ADAFRUIT_BUSIO}"
+          arduino-cli lib install "Adafruit MAX1704X@${LIB_ADAFRUIT_MAX1704X}"
+          arduino-cli lib install "ArduinoJson@${LIB_ARDUINOJSON}"
+          arduino-cli lib install "WebSockets@${LIB_WEBSOCKETS}"
+          arduino-cli lib install "ESP Async WebServer@${LIB_ESPASYNCWEBSERVER}"
+          arduino-cli lib install "Async TCP@${LIB_ASYNCTCP}"
+          arduino-cli lib install "NimBLE-Arduino@${LIB_NIMBLE_ARDUINO}"
+
+          echo "Installed libraries:"
+          arduino-cli lib list
+
+      - name: Build firmware
+        working-directory: vail-summit
+        run: |
+          arduino-cli compile \
             --fqbn "esp32:esp32:adafruit_feather_esp32s3:CDCOnBoot=cdc,PartitionScheme=huge_app,PSRAM=enabled,FlashSize=4M,USBMode=hwcdc" \
-            --output-dir ../build \
+            --output-dir build \
             --export-binaries \
-            ..
+            .
 
           echo "Built files:"
-          ls -lh ../build
+          ls -lh build
 
       - name: Normalize binary filenames
         working-directory: vail-summit/build
@@ -56,7 +97,6 @@ jobs:
               mv "$f" "${f#vail-summit.ino.}"
             fi
           done
-          # Rename merged.bin too if present
           [ -f vail-summit.ino.merged.bin ] && mv vail-summit.ino.merged.bin merged.bin || true
           echo "Final files:"
           ls -lh


### PR DESCRIPTION
## What's broken

PR #68 (just merged) assumed the vail-summit repo had its `arduino-cli/` folder checked in. It does not — that folder is gitignored, only living on developer machines locally. The first dispatched run failed immediately at `cd vail-summit/arduino-cli` with "No such file or directory".

## Fix

Replaces the bundled-env approach with explicit pinned-version installs via `arduino-cli`, mirroring the versions documented in the vail-summit local build setup:

| Component | Version |
|---|---|
| esp32:esp32 core | 2.0.14 |
| LovyanGFX | 1.1.16 |
| lvgl | 8.3.11 |
| Adafruit LC709203F | 1.3.4 |
| Adafruit BusIO | 1.17.4 |
| Adafruit MAX1704X | 1.0.3 |
| ArduinoJson | 7.0.4 |
| WebSockets | 2.4.1 |
| ESP Async WebServer | 3.6.0 |
| Async TCP | 3.3.2 |
| NimBLE-Arduino | 1.4.2 |

Versions live in workflow `env:` vars at the top of the file so they're easy to bump alongside any local arduino-cli/ updates.

Same `fqbn` flags, same deploy targets, same `BUILD_INFO.txt` — only the dependency acquisition step changed.

## Test plan

After merge:
1. Dispatch the workflow with `source_branch=pr1-merge-and-fix`, `deploy_target=test`
2. Should complete in ~5 min
3. `docs/firmware_files/test/summit/BUILD_INFO.txt` should appear with version 0.527

## Summary by Sourcery

Switch the summit firmware CI workflow to install pinned Arduino core and library dependencies via arduino-cli instead of relying on a bundled local environment.

CI:
- Define pinned versions for the ESP32 core and required Arduino libraries as workflow environment variables.
- Replace use of a checked-in arduino-cli directory with setup-arduino-cli and explicit core/library installation steps in the summit firmware build job.