### PR TITLE
summit firmware workflow: place lv_conf.h next to lvgl library

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -76,6 +76,20 @@ jobs:
           echo "Installed libraries:"
           arduino-cli lib list
 
+      - name: Place lv_conf.h next to lvgl library
+        # vail-summit ships its lv_conf.h at the repo root. LVGL's
+        # lv_conf_internal.h expects it at "../../lv_conf.h" relative to
+        # src/misc/ — i.e. one level above the lvgl/ library folder. Local
+        # builds put it in arduino-cli/user/libraries/lv_conf.h. Mirror that
+        # by copying the source-controlled copy into ~/Arduino/libraries/.
+        run: |
+          if [ ! -f vail-summit/lv_conf.h ]; then
+            echo "ERROR: vail-summit/lv_conf.h not found in source checkout"
+            exit 1
+          fi
+          cp vail-summit/lv_conf.h ~/Arduino/libraries/lv_conf.h
+          echo "Placed lv_conf.h at: $(ls -l ~/Arduino/libraries/lv_conf.h)"
+
       - name: Build firmware
         working-directory: vail-summit
         run: |


### PR DESCRIPTION
## What's broken

PR #69 (just merged) got us past the missing arduino-cli folder, but the build still fails because LVGL can't find its config:

```
fatal error: ../../lv_conf.h: No such file or directory
```

LVGL's `lv_conf_internal.h` does `#include "../../lv_conf.h"` expecting the config one directory above the lvgl library folder. Local builds satisfy this because the bundled `arduino-cli/user/libraries/` keeps a copy of `lv_conf.h` next to the lvgl folder. CI doesn't.

## Fix

vail-summit ships its canonical `lv_conf.h` at the repo root. New workflow step copies it to `~/Arduino/libraries/lv_conf.h` after lvgl is installed, so the relative include resolves the same way it does locally.

Fails fast with a clear error if the file isn't in the checkout (catches a future repo restructure).

## Test plan

After merge:
1. Re-dispatch `Build and Deploy Summit Firmware` with `source_branch=pr1-merge-and-fix`, `deploy_target=test`
2. Build should now succeed
3. `docs/firmware_files/test/summit/BUILD_INFO.txt` should appear with version 0.527

## Summary by Sourcery

Ensure the Summit firmware CI workflow correctly exposes LVGL's configuration file to the Arduino build

CI:
- Add a workflow step to copy the canonical lv_conf.h from the repository root into the Arduino libraries directory so LVGL's relative include resolves in CI builds
- Fail the workflow early with a clear error message if lv_conf.h is missing from the checkout