### PR TITLE
summit firmware workflow: force -mtext-section-literals + --clean

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -93,10 +93,19 @@ jobs:
       - name: Build firmware
         working-directory: vail-summit
         run: |
+          # -mtext-section-literals is required for sketches that produce a
+          # .text section large enough to overrun the l32r literal-pool range
+          # (~32KB). The ESP32-S3 variant of the platform.txt sets this flag
+          # for compiler.cpp.flags.esp32s3, but on a fresh CI install the s3
+          # variant isn't always picked up — adding it explicitly via
+          # --build-property guarantees the sketch gets it. ArduinoJson 7.0.4
+          # in particular pushes us over the boundary without it.
           arduino-cli compile \
             --fqbn "esp32:esp32:adafruit_feather_esp32s3:CDCOnBoot=cdc,PartitionScheme=huge_app,PSRAM=enabled,FlashSize=4M,USBMode=hwcdc" \
+            --build-property "compiler.cpp.extra_flags=-mtext-section-literals" \
             --output-dir build \
             --export-binaries \
+            --clean \
             .
 
           echo "Built files:"


### PR DESCRIPTION
## What's broken

PR #70 (just merged) got us past the lv_conf step. Build now reaches the link phase but fails with a swarm of:

```
dangerous relocation: l32r: literal target out of range
  (try using text-section-literals)
```

The ESP32 platform.txt sets `compiler.cpp.flags.esp32s3` to include `-mtext-section-literals`, but on a fresh arduino-cli install the s3 variant isn't always picked up. ArduinoJson 7.0.4's heavy float-formatting templates push the .text section past the l32r addressable range without it.

## Fix

1. Add `--build-property "compiler.cpp.extra_flags=-mtext-section-literals"` to guarantee the flag reaches sketch compilation regardless of how arduino-cli interprets the platform.txt variant.

2. Add `--clean` to match the local `new-update` build skill, which warns that without it cached object files can carry stale version strings (and stale layouts in our case).

## Test plan

After merge:
1. Re-dispatch `Build and Deploy Summit Firmware` with `source_branch=pr1-merge-and-fix`, `deploy_target=test`
2. Build should compile + link cleanly
3. `docs/firmware_files/test/summit/BUILD_INFO.txt` should appear with version 0.527
4. `vail-summit.bin` should be roughly the same size as a local build (~2.4MB)

## Summary by Sourcery

Ensure the Summit firmware CI build uses the required ESP32 compiler flags and clean builds to avoid stale artifacts.

Build:
- Add explicit -mtext-section-literals compiler flag to the Arduino CLI build for Summit firmware to prevent linker relocation errors.
- Enable --clean in the Arduino CLI Summit firmware build step so CI performs clean builds without reusing cached objects.