### PR TITLE
summit firmware workflow: don't clean workspace on second checkout

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -170,6 +170,9 @@ jobs:
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
           path: vail-adapter
+          # Default cleans GITHUB_WORKSPACE before checkout, which would
+          # wipe the freshly built vail-summit/build/ artifacts. Disable.
+          clean: false
 
       - name: Copy firmware files into vail-adapter
         if: ${{ inputs.deploy_target != 'none' }}


### PR DESCRIPTION
## What's broken

PR #71 (just merged) got us a clean compile + link. Build artifacts upload step also passed. But deploy fails with:

```
cp: cannot stat 'vail-summit/build/vail-summit.bin': No such file or directory
```

The second `actions/checkout@v4` (for vail-adapter master) defaults to `clean: true`, which runs `git clean -ffdx` on `GITHUB_WORKSPACE` before fetching. That wipes the `vail-summit/` source tree and `vail-summit/build/` artifacts the previous steps populated.

## Fix

Adds `clean: false` to the deploy checkout. The new checkout still pulls vail-adapter into its own `path: vail-adapter` subdirectory; vail-summit/ is left alone.

Failed run: https://github.com/Vail-CW/vail-adapter/actions/runs/25630785236

## Test plan

After merge, re-dispatch with `source_branch=pr1-merge-and-fix`, `deploy_target=test`. Should now finish all the way through to a commit on master.

## Summary by Sourcery

Prevent the summit firmware deployment workflow from deleting previously built artifacts during the deploy phase by adjusting the secondary repository checkout behavior.

Bug Fixes:
- Preserve vail-summit build artifacts during the deploy job by disabling automatic workspace cleaning on the second checkout step in the summit firmware workflow.

CI:
- Adjust the summit firmware GitHub Actions workflow checkout step to avoid cleaning the workspace when fetching the vail-adapter repository for deployment.