### PR TITLE
summit firmware workflow: stash build outputs in /tmp before deploy checkout

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -162,6 +162,18 @@ jobs:
           echo "msg=$COMMIT_MSG" >> $GITHUB_OUTPUT
           echo "Target: docs/$TARGET_DIR"
 
+      - name: Stash build outputs outside the workspace before deploy checkout
+        # actions/checkout (run again below for vail-adapter) reliably wipes
+        # GITHUB_WORKSPACE even with clean: false in some scenarios. Move the
+        # built binaries to /tmp where neither checkout will touch them.
+        if: ${{ inputs.deploy_target != 'none' }}
+        run: |
+          mkdir -p /tmp/summit-build
+          cp vail-summit/build/bootloader.bin   /tmp/summit-build/
+          cp vail-summit/build/partitions.bin   /tmp/summit-build/
+          cp vail-summit/build/vail-summit.bin  /tmp/summit-build/
+          ls -lh /tmp/summit-build/
+
       - name: Checkout vail-adapter master for deploy
         if: ${{ inputs.deploy_target != 'none' }}
         uses: actions/checkout@v4
@@ -170,8 +182,6 @@ jobs:
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
           path: vail-adapter
-          # Default cleans GITHUB_WORKSPACE before checkout, which would
-          # wipe the freshly built vail-summit/build/ artifacts. Disable.
           clean: false
 
       - name: Copy firmware files into vail-adapter
@@ -179,9 +189,9 @@ jobs:
         run: |
           DEST="vail-adapter/docs/${{ steps.target.outputs.dir }}"
           mkdir -p "$DEST"
-          cp vail-summit/build/bootloader.bin "$DEST/"
-          cp vail-summit/build/partitions.bin "$DEST/"
-          cp vail-summit/build/vail-summit.bin "$DEST/"
+          cp /tmp/summit-build/bootloader.bin   "$DEST/"
+          cp /tmp/summit-build/partitions.bin   "$DEST/"
+          cp /tmp/summit-build/vail-summit.bin  "$DEST/"
 
           # Provenance for testers
           cat > "$DEST/BUILD_INFO.txt" <<EOF


### PR DESCRIPTION
## What's broken

PR #72's `clean: false` didn't actually preserve the build artifacts. Run https://github.com/Vail-CW/vail-adapter/actions/runs/25631082768 still failed with:

```
cp: cannot stat 'vail-summit/build/vail-summit.bin': No such file or directory
```

Even with `clean: false` on the second `actions/checkout@v4`, something about the action's workspace handling is losing the prior build outputs. Build itself succeeded, artifact upload succeeded — so the file existed up to that point.

## Fix

Copy the three .bin files to `/tmp/summit-build/` before the deploy checkout runs. `/tmp` is outside `GITHUB_WORKSPACE` so neither checkout can touch it. Deploy step then copies from `/tmp` into the vail-adapter tree.

Same robustness pattern as the artifact upload (uploads run before the second checkout and have always succeeded — confirming the files exist there).

## Test plan
After merge, re-dispatch with `source_branch=pr1-merge-and-fix`, `deploy_target=test`. Should reach `Commit and push to vail-adapter` and create the deploy commit.

## Summary by Sourcery

CI:
- Add a step to copy Summit firmware .bin artifacts into /tmp before the deploy checkout and update the deploy step to copy from this stash into the vail-adapter repo instead of the original build directory.