### PR TITLE
summit firmware workflow: fix binary rename (was producing 'bin' not 'vail-summit.bin')

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -114,13 +114,14 @@ jobs:
       - name: Normalize binary filenames
         working-directory: vail-summit/build
         run: |
-          # arduino-cli prefixes outputs with "<sketch>.ino." — strip that.
-          for f in vail-summit.ino.bootloader.bin vail-summit.ino.partitions.bin vail-summit.ino.bin; do
-            if [ -f "$f" ]; then
-              mv "$f" "${f#vail-summit.ino.}"
-            fi
-          done
-          [ -f vail-summit.ino.merged.bin ] && mv vail-summit.ino.merged.bin merged.bin || true
+          # arduino-cli emits files prefixed with "<sketch>.ino." — rename to
+          # the names the updater serves. Three explicit renames (a generic
+          # for-loop with parameter expansion would map vail-summit.ino.bin
+          # to "bin" instead of "vail-summit.bin").
+          [ -f vail-summit.ino.bootloader.bin ] && mv vail-summit.ino.bootloader.bin bootloader.bin
+          [ -f vail-summit.ino.partitions.bin ] && mv vail-summit.ino.partitions.bin partitions.bin
+          [ -f vail-summit.ino.bin ]            && mv vail-summit.ino.bin            vail-summit.bin
+          [ -f vail-summit.ino.merged.bin ]     && mv vail-summit.ino.merged.bin     merged.bin || true
           echo "Final files:"
           ls -lh
 


### PR DESCRIPTION
## What's broken

Build still fails at `Stash build outputs` step:

```
cp: cannot stat 'vail-summit/build/vail-summit.bin': No such file or directory
```

Root cause is in the prior Normalize step. The shell parameter expansion in:

```bash
for f in vail-summit.ino.bootloader.bin vail-summit.ino.partitions.bin vail-summit.ino.bin; do
  mv "$f" "${f#vail-summit.ino.}"
done
```

works for two of the three files (e.g. `vail-summit.ino.bootloader.bin` → `bootloader.bin`), but for `vail-summit.ino.bin` the result of `${f#vail-summit.ino.}` is just `bin` — not `vail-summit.bin`. Build logs from run 25631201780 confirmed only `bootloader.bin` and `partitions.bin` ended up in the build dir.

Upload artifacts didn't fail because the default `if-no-files-found: warn` just logs a warning when the third file isn't there.

## Fix

Replace the for-loop with three explicit renames so the .bin file lands at `vail-summit.bin`.

## Test plan

After merge, re-dispatch with `source_branch=pr1-merge-and-fix`, `deploy_target=test`. Should reach the commit step and create `docs/firmware_files/test/summit/{bootloader,partitions,vail-summit}.bin` + `BUILD_INFO.txt`.

## Summary by Sourcery

Fix Summit firmware GitHub Actions workflow to correctly rename Arduino build outputs so the expected firmware binaries are produced.

Bug Fixes:
- Correct the filename normalization step so vail-summit.ino.bin is renamed to vail-summit.bin instead of an incorrect name.
- Ensure all expected firmware artifacts (bootloader, partitions, merged, and main binary) are consistently produced for later steps in the workflow.