### PR TITLE
summit firmware workflow: BUILD_INFO source_commit reflects vail-summit checkout

### DIFF
--- a/.github/workflows/build_summit_firmware.yml
+++ b/.github/workflows/build_summit_firmware.yml
@@ -125,15 +125,21 @@ jobs:
           echo "Final files:"
           ls -lh
 
-      - name: Capture firmware version from config.h
+      - name: Capture firmware version + source commit
         id: ver
         working-directory: vail-summit
         run: |
           VER=$(grep -E '^#define[[:space:]]+FIRMWARE_VERSION' src/core/config.h | sed -E 's/.*"([^"]+)".*/\1/')
           DATE=$(grep -E '^#define[[:space:]]+FIRMWARE_DATE' src/core/config.h | sed -E 's/.*"([^"]+)".*/\1/')
+          # Capture the actual checked-out vail-summit SHA. github.sha refers
+          # to the workflow repo (vail-adapter), which is misleading in
+          # BUILD_INFO since the firmware is built from vail-summit source.
+          SOURCE_SHA=$(git rev-parse HEAD)
           echo "version=${VER:-unknown}" >> $GITHUB_OUTPUT
           echo "date=${DATE:-unknown}" >> $GITHUB_OUTPUT
+          echo "source_sha=${SOURCE_SHA}" >> $GITHUB_OUTPUT
           echo "Firmware version: $VER ($DATE)"
+          echo "Source commit (vail-summit): $SOURCE_SHA"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -200,7 +206,8 @@ jobs:
           Version:        ${{ steps.ver.outputs.version }}
           Firmware date:  ${{ steps.ver.outputs.date }}
           Built from:     Vail-CW/vail-summit @ ${{ inputs.source_branch }}
-          Source commit:  ${{ github.sha }}
+          Source commit:  ${{ steps.ver.outputs.source_sha }}
+          Workflow:       Vail-CW/vail-adapter @ ${{ github.sha }}
           Deploy target:  ${{ steps.target.outputs.dir }}
           Built at:       $(date -u +"%Y-%m-%dT%H:%M:%SZ")
           EOF


### PR DESCRIPTION
## Bug

`BUILD_INFO.txt`'s `Source commit` field used `${{ github.sha }}`, which inside this workflow resolves to vail-adapter's master HEAD — not the vail-summit source actually built.

For run [#25631323663](https://github.com/Vail-CW/vail-adapter/actions/runs/25631323663) this showed `f53a920` (the workflow PR #74 merge commit on vail-adapter) instead of `cf7ee56` (the actual vail-summit `pr1-merge-and-fix` tip that was built).

## Fix

Captures the real source SHA via `git rev-parse HEAD` inside the vail-summit checkout dir, and reports both fields in BUILD_INFO so testers can see what was built AND which workflow rev built it.

## Summary by Sourcery

Ensure BUILD_INFO.txt records the actual vail-summit source commit used for firmware builds and clearly distinguishes it from the workflow repository revision.

Bug Fixes:
- Fix BUILD_INFO.txt incorrectly reporting the workflow repository commit instead of the built vail-summit source commit.

Enhancements:
- Add capture and logging of the vail-summit HEAD SHA during the build and include both source and workflow commit information in BUILD_INFO.txt for better traceability.