### PR TITLE
Add MoMIDI-style timing to sent MIDI events

### DIFF
--- a/adapter.cpp
+++ b/adapter.cpp
@@ -37,6 +37,8 @@ this->txRelays[1] = false; // dah
 this->lastPaddlePressed = PADDLE_DIT;
 this->ditKeyPressed = false;
 this->dahKeyPressed = false;
+this->midiEventPreviousTime = millis()-(MAX_MIDI_EVENT_DELTA+1);
+this->sendMidiEventDeltaTimes = false;
 }
 
 bool VailAdapter::KeyboardMode() {
@@ -89,6 +91,40 @@ this->dahIsHeld = false;
 this->dahHoldStartTime = 0;
 }
 
+// The time since the previous key up/down event is encoded into a 14-bit
+// base 126 value. The upper 7 bits of this value are sent in a CC event, while
+// the lower 7 bits are sent in the note event's velocity value, avoiding 0 and 127
+// velocity values. Time values up to 16128 milliseconds can be sent. If the elapsed
+// time exceeds this, a value of 0 is sent for the time, indicating that the timer
+// has been reset. The algorithm is described more fully in the MoMIDI specification.
+// See https://github.com/NetKeyer/MoMIDI-Spec
+//
+// This function sends the CC event with the high 7 bits of the time value
+// and returns the low 7 bits to be sent later with the note on/off event.
+uint8_t VailAdapter::sendMidiEventDeltaTimeHigh(uint8_t key) {
+    uint8_t header;
+    uint8_t status_byte;
+    uint8_t delta_high;
+    uint8_t delta_low;
+    unsigned long currentTime = millis();
+    unsigned long delta = currentTime - this->midiEventPreviousTime;
+
+    this->midiEventPreviousTime = currentTime;
+    if (delta == 0 || delta > MAX_MIDI_EVENT_DELTA) {
+        delta_high = 0;
+        delta_low = 0;
+    } else {
+        delta -= 1; // Subtract 1 for base 126; we only support values in [1, 16128]
+        delta_high = delta / 126;
+        delta_low = delta % 126 + 1; // Add 1 so the value falls in [1, 126]
+    }
+    header = 0x0B; // CIN = 0x0B Change Control
+    status_byte = 0xB0; // Change Control
+    midiEventPacket_t event = {header, status_byte, key, delta_high};
+    MidiUSB.sendMIDI(event);
+    return delta_low;
+}
+
 // Corrected MIDI key event function
 void VailAdapter::midiKey(uint8_t key, bool down) {
 uint8_t header;
@@ -104,6 +140,10 @@ if (down) { // Note On
     status_byte = 0x80; // MIDI Status = 0x80 (Note Off, Channel 1)
     velocity = 0x00;    // Velocity for Note Off (0x00 is common)
 }
+
+if (this->sendMidiEventDeltaTimes)
+    velocity = sendMidiEventDeltaTimeHigh(key);
+
 // Construct the MIDI event packet for MIDIUSB library
 midiEventPacket_t event = {header, status_byte, key, velocity};
 MidiUSB.sendMIDI(event);
@@ -795,6 +835,10 @@ this->txNote = event.byte3;
 Serial.print("TX Note set to: "); Serial.println(this->txNote);
 
 saveSettingsToEEPROM(getCurrentKeyerType(), this->ditDuration, this->txNote);
+break;
+case 3:
+this->sendMidiEventDeltaTimes = (event.byte3 > 0x3f);
+Serial.print("MIDI timing: "); Serial.println(this->sendMidiEventDeltaTimes ? "ON" : "OFF");
 break;
 }
 break;

--- a/adapter.h
+++ b/adapter.h
@@ -6,6 +6,8 @@
 #include "config.h" // Include config.h
 #include "memory.h" // Include memory.h for recording state
 
+#define MAX_MIDI_EVENT_DELTA 16128 // 2^7 * 126 milliseconds
+
 class VailAdapter: public Transmitter {
 private:
     unsigned int txNote = DEFAULT_TONE_NOTE;
@@ -38,6 +40,10 @@ private:
     bool ditKeyPressed = false;
     bool dahKeyPressed = false;
 
+    // Track last Time a MIDI event was sent
+    unsigned long midiEventPreviousTime = 0;
+    bool sendMidiEventDeltaTimes= false;
+
     // CW memory recording
     RecordingState* recordingState = nullptr;
 
@@ -46,6 +52,8 @@ private:
 
     void setRadioDit(bool active);
     void setRadioDah(bool active);
+
+    uint8_t sendMidiEventDeltaTimeHigh(uint8_t key);
 
 public:
     VailAdapter(unsigned int PiezoPin);

--- a/docs/MIDI_INTEGRATION_SPEC.md
+++ b/docs/MIDI_INTEGRATION_SPEC.md
@@ -53,6 +53,16 @@ The Vail Adapter responds to the following MIDI message types:
 - **Tuning**: equal temperament
 - **Example**: `B0 02 2D` sets sidetone to note 45 = A2 (110 Hz)
 
+#### CC3 - Enable sending MIDI event time delta
+**Purpose**: Switch between sending normal MIDI notes and notes with event time deltas
+
+- **Message**: `B0 03 xx`
+- **Values**:
+  - `00-3F` (0-63): Disable sending of event time deltas
+  - `40-7F` (64-127): Enable sending of event time deltas
+- **Default**: Sending of time deltas is disabled
+- **Example**: `B0 03 7F` enables sending of event time deltas
+
 ### Program Change Messages (0xCn)
 
 #### Keyer Mode Selection


### PR DESCRIPTION
When sending each key up/down event, also send the time in milliseconds since the previous key up/down event. The interval is encoded into a 14-bit base 126 value. The upper 7 bits of this value are sent in a CC event, while the lower 7 bit are sent in the note's velocity field, avoiding values of 0 and 127. Intervals of up to 16128 (128*126) milliseconds can be sent. If that time is exceeded, a time value of 0 is sent. These timing values can be used by the receiving system to recreate the morse elements with 1 mS accuracy, regardless of the jitter introduced by the communication path.

The algorithm is described more fully in the MoMIDI specfication. See https://github.com/NetKeyer/MoMIDI-Spec

Jitter of a few milliseconds may not be significant at lower words per minute, but becomes significant at higher WPM. I find it satisfying to have end-to-end preservation of morse element and spacing lengths. They are generated in the keyer and accurately recreated at the transmitter.

## Summary by Sourcery

Add optional MoMIDI-style encoding of inter-event timing into outgoing MIDI key events and expose it via a configurable control change.

New Features:
- Encode time deltas between key up/down events into MIDI CC and velocity fields when enabled.
- Add a MIDI CC3 control to toggle sending of event time deltas on or off.

Documentation:
- Document the CC3-based control for enabling or disabling MIDI event time delta transmission in the MIDI integration specification.