### PR TITLE
Use short 8.3-safe firmware filenames to fix Windows flashing hang

### DIFF
--- a/.github/workflows/build_uf2.yml
+++ b/.github/workflows/build_uf2.yml
@@ -27,49 +27,54 @@ jobs:
       matrix:
         include:
           # --- XIAO SAMD21 Configurations ---
+          # uf2_name is a short, DOS 8.3-safe code (<=8 chars, single dot). The
+          # release step appends a 2-digit version code, e.g. xb2 -> xb2_50.uf2.
+          # Long names (xiao_basic_pcb_v2_v5.0.uf2) force Windows to write a VFAT
+          # long-filename entry onto the SAMD21 bootloader's tiny emulated FAT
+          # drive, which can hang/fail the drag-to-bootloader copy on Win10/11.
           - board_name: "XIAO_SAMD21"
             fqbn: "Seeeduino:samd:seeed_XIAO_m0"
             hw_define: "V1_Basic_PCB"
-            uf2_name: "xiao_basic_pcb_v1.uf2"
+            uf2_name: "xb1.uf2"
           - board_name: "XIAO_SAMD21"
             fqbn: "Seeeduino:samd:seeed_XIAO_m0"
             hw_define: "V2_Basic_PCB"
-            uf2_name: "xiao_basic_pcb_v2.uf2"
+            uf2_name: "xb2.uf2"
           - board_name: "XIAO_SAMD21"
             fqbn: "Seeeduino:samd:seeed_XIAO_m0"
             hw_define: "NO_PCB_GITHUB_SPECS"
-            uf2_name: "xiao_non_pcb.uf2"
+            uf2_name: "xnp.uf2"
           - board_name: "XIAO_SAMD21"
             fqbn: "Seeeduino:samd:seeed_XIAO_m0"
             hw_define: "Advanced_PCB"
-            uf2_name: "xiao_advanced_pcb.uf2"
+            uf2_name: "xad.uf2"
           # --- Adafruit QT Py SAMD21 Configurations ---
           - board_name: "QTPY_SAMD21"
             fqbn: "adafruit:samd:adafruit_qtpy_m0"
             hw_define: "V1_Basic_PCB"
-            uf2_name: "qtpy_basic_pcb_v1.uf2"
+            uf2_name: "qb1.uf2"
           - board_name: "QTPY_SAMD21"
             fqbn: "adafruit:samd:adafruit_qtpy_m0"
             hw_define: "V2_Basic_PCB"
-            uf2_name: "qtpy_basic_pcb_v2.uf2"
+            uf2_name: "qb2.uf2"
           - board_name: "QTPY_SAMD21"
             fqbn: "adafruit:samd:adafruit_qtpy_m0"
             hw_define: "Advanced_PCB"
-            uf2_name: "qtpy_advanced_pcb.uf2"
+            uf2_name: "qad.uf2"
           - board_name: "QTPY_SAMD21"
             fqbn: "adafruit:samd:adafruit_qtpy_m0"
             hw_define: "NO_PCB_GITHUB_SPECS"
-            uf2_name: "qtpy_non_pcb.uf2"
-          # --- Adafruit TRRS Trinkey SAMD21 Configuration ---
+            uf2_name: "qnp.uf2"
+          # --- Adafruit TRRS Trinkey SAMD21 Configuration (Vail Lite) ---
           - board_name: "TRRS_TRINKEY"
             fqbn: "adafruit:samd:adafruit_TRRStrinkey_m0"
             hw_define: "TRRS_TRINKEY"
-            uf2_name: "trinkey_vail_adapter.uf2"
+            uf2_name: "vl.uf2"
           # --- Arduino Micro (ATmega32U4) — produces .hex, not .uf2 ---
           - board_name: "ARDUINO_MICRO"
             fqbn: "arduino:avr:micro"
             hw_define: "ARDUINO_MICRO_BOARD"
-            uf2_name: "arduino_micro.hex"
+            uf2_name: "mic.hex"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -156,13 +161,21 @@ jobs:
         run: |
           set -e
           mkdir -p release_assets
-          # Artifacts download into per-name subdirs; flatten and stamp the tag
-          # into each filename, e.g. xiao_basic_pcb_v2.uf2 -> xiao_basic_pcb_v2_v5.0.uf2
+          # Stamp a short, digits-only version code onto each short board code so
+          # the asset name stays DOS 8.3-safe (<=8 chars, single dot). The code is
+          # major.minor with the dot removed, e.g. v5.0 -> 50, v5.2.0-beta.1 -> 52:
+          #   xb2.uf2 -> xb2_50.uf2
+          # Embedding the raw tag (v5.0) would add a second dot and break 8.3.
+          VERCODE="$(printf '%s' "$TAG" | sed -E 's/^[vV]?([0-9]+)\.([0-9]+).*/\1\2/')"
+          # Fallback for tags without a major.minor: strip to alphanumerics.
+          case "$VERCODE" in *[!0-9A-Za-z]*|'') VERCODE="$(printf '%s' "$TAG" | tr -cd '0-9A-Za-z')";; esac
+          echo "Version code for $TAG: $VERCODE"
+          # Artifacts download into per-name subdirs; flatten and stamp.
           find all_fw -type f \( -name "*.uf2" -o -name "*.hex" \) | while read -r f; do
             base="$(basename "$f")"
             name="${base%.*}"
             ext="${base##*.}"
-            cp "$f" "release_assets/${name}_${TAG}.${ext}"
+            cp "$f" "release_assets/${name}_${VERCODE}.${ext}"
           done
           echo "Assets to upload to $TAG:"
           ls -1 release_assets

--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -551,6 +551,6 @@
 
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="script.js?v=2026-06-11.1" defer></script>
+<script src="script.js?v=2026-06-13.1" defer></script>
 </body>
 </html>

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -183,36 +183,91 @@ const adapterReleases = {
 
 // Resolve the base firmware name (no extension) and extension for the current
 // board/model selection. Returns null if the selection is incomplete.
+//
+// `base` is the short, 8.3-safe asset code (e.g. "xb2" -> xb2_50.uf2). The build
+// stamps the major.minor version onto it as the release asset name. `legacyBase`
+// is the old long name (e.g. "xiao_basic_pcb_v2") so the updater keeps finding
+// assets on releases that haven't been re-stamped yet — this lets the new code
+// deploy before the existing release assets are migrated, with no broken window.
 function getFirmwareBase() {
-    if (wizardState.model === 'vail_lite') return { base: 'trinkey_vail_adapter', ext: 'uf2' };
-    if (wizardState.board === 'micro') return { base: 'arduino_micro', ext: 'hex' };
+    if (wizardState.model === 'vail_lite') return { base: 'vl', legacyBase: 'trinkey_vail_adapter', ext: 'uf2' };
+    if (wizardState.board === 'micro') return { base: 'mic', legacyBase: 'arduino_micro', ext: 'hex' };
     if (!wizardState.model || !wizardState.board) return null;
-    if (wizardState.model === 'basic_pcb') return { base: `${wizardState.board}_basic_pcb_v2`, ext: 'uf2' };
-    if (wizardState.model === 'advanced_pcb') return { base: `${wizardState.board}_advanced_pcb`, ext: 'uf2' };
-    return { base: `${wizardState.board}_non_pcb`, ext: 'uf2' };
+    const p = wizardState.board === 'xiao' ? 'x' : 'q'; // short board prefix
+    if (wizardState.model === 'basic_pcb') return { base: `${p}b2`, legacyBase: `${wizardState.board}_basic_pcb_v2`, ext: 'uf2' };
+    if (wizardState.model === 'advanced_pcb') return { base: `${p}ad`, legacyBase: `${wizardState.board}_advanced_pcb`, ext: 'uf2' };
+    return { base: `${p}np`, legacyBase: `${wizardState.board}_non_pcb`, ext: 'uf2' };
+}
+
+// Build a short, DOS 8.3-safe download filename (<=8-char name + single dot +
+// 3-char extension) so Windows never has to write a VFAT long-filename entry
+// onto the SAMD21 bootloader's tiny emulated FAT volume. Long asset names like
+// "xiao_basic_pcb_v2_v5.0.uf2" can hang or fail the drag-to-bootloader copy on
+// Windows 10/11, leaving the board stuck in storage (bootloader) mode. The
+// bootloader flashes by UF2 block magic and ignores the filename, so any short
+// name works; we keep major.minor so users still recognize the version. Patch
+// and pre-release suffixes are dropped to stay within the 8-char budget.
+// e.g. "v5.0" -> "VAIL_5_0.uf2", "v5.1.0" -> "VAIL_5_1.uf2".
+function shortFirmwareName(tag, ext) {
+    const m = String(tag || '').match(/(\d+)(?:\.(\d+))?/);
+    const major = m ? m[1] : '0';
+    const minor = m && m[2] != null ? m[2] : '0';
+    return `VAIL_${major}_${minor}.${ext}`;
 }
 
 // Resolve the firmware download for the current selection + selected version.
 // Firmware comes exclusively from the selected release's tag-stamped asset.
 // .hex (Arduino Micro) is fetched in JS, so its asset URL is routed through the
-// CORS proxy; .uf2 is a direct anchor download and needs no proxy.
+// CORS proxy; .uf2 is a direct anchor download (with a Blob-based short-name
+// fallback handled at click time — see downloadFirmwareShortName).
 function getFirmwareFile() {
     const sel = getFirmwareBase();
     if (!sel) return null;
-    const { base, ext } = sel;
+    const { base, legacyBase, ext } = sel;
 
     // A release must be selected, and it must carry this board's asset.
     if (!adapterReleases.selected) {
         return { unavailable: true, version: '(none)', board: `${base}.${ext}` };
     }
-    const asset = adapterReleases.findAsset(base, ext);
+    // Prefer the new short-name asset; fall back to the legacy long name for
+    // releases that haven't been re-stamped yet.
+    const asset = adapterReleases.findAsset(base, ext) ||
+        (legacyBase ? adapterReleases.findAsset(legacyBase, ext) : null);
     if (!asset) {
         return { unavailable: true, version: adapterReleases.selected.tag_name, board: `${base}.${ext}` };
     }
     const url = ext === 'hex'
         ? `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${adapterReleases.selected.tag_name}/${asset.name}`
         : asset.browser_download_url;
-    return { url, filename: asset.name };
+    return { url, filename: asset.name, downloadName: shortFirmwareName(adapterReleases.selected.tag_name, ext) };
+}
+
+// Download the UF2 under its short 8.3-safe name. The <a download> filename is
+// ignored for cross-origin GitHub asset URLs, so the browser would otherwise
+// keep GitHub's long asset name. Fetch through the CORS proxy and save a Blob,
+// where the short download name IS honored. Falls back to the direct GitHub
+// link (long name, but still flashes) if the proxied fetch fails.
+async function downloadFirmwareShortName(firmwareFile) {
+    const tag = adapterReleases.selected && adapterReleases.selected.tag_name;
+    const proxyUrl = `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${tag}/${firmwareFile.filename}`;
+    const saveBlob = (href, revoke) => {
+        const a = document.createElement('a');
+        a.href = href;
+        a.download = firmwareFile.downloadName;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        if (revoke) setTimeout(() => URL.revokeObjectURL(href), 10000);
+    };
+    try {
+        const resp = await fetch(proxyUrl, { cache: 'no-cache' });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const blob = await resp.blob();
+        saveBlob(URL.createObjectURL(blob), true);
+    } catch (err) {
+        console.log('Short-name download failed, falling back to direct link:', err.message);
+        saveBlob(firmwareFile.url, false);
+    }
 }
 
 // Get friendly names for display
@@ -466,7 +521,10 @@ function updateStep3Content() {
         downloadButton.setAttribute('aria-disabled', 'true');
         downloadText.textContent = `${firmwareFile.board} not available in ${firmwareFile.version}`;
     } else if (firmwareFile) {
-        const savedName = firmwareFile.filename;
+        const savedName = firmwareFile.downloadName || firmwareFile.filename;
+        // href is the direct-link fallback; the click handler does a Blob
+        // download under the short 8.3 name so Windows' drag-to-bootloader copy
+        // doesn't choke on a long filename.
         downloadButton.href = firmwareFile.url;
         downloadButton.download = savedName;
         downloadText.textContent = `Download ${savedName}`;
@@ -832,6 +890,17 @@ document.addEventListener('DOMContentLoaded', () => {
         if (this.classList.contains('disabled')) {
             event.preventDefault();
             alert("Please complete the previous steps first.");
+            return;
+        }
+        // For UF2 boards, save under a short 8.3-safe name via a Blob download
+        // so the Windows drag-to-bootloader copy doesn't hang on a long filename
+        // (which leaves the board stuck in storage mode). .hex (Micro) flashes
+        // over WebSerial on its own page, so it never uses this button.
+        const firmwareFile = getFirmwareFile();
+        if (firmwareFile && !firmwareFile.unavailable &&
+            firmwareFile.downloadName && firmwareFile.downloadName.endsWith('.uf2')) {
+            event.preventDefault();
+            downloadFirmwareShortName(firmwareFile);
         }
     });
 });


### PR DESCRIPTION
## Problem

Two testers in the week after the V5.0 release-asset rollout reported that dragging the `.uf2` onto the bootloader drive **hangs or fails partway** on Windows 10/11, after which the adapter comes up in storage (bootloader) mode on every plug-in. One worked around it by flashing from an **Android phone** — which proves the firmware/file is fine and the failure is in the *Windows copy*, not the device.

## Cause

V5.0 was the first release to distribute firmware as version-stamped GitHub assets like `xiao_basic_pcb_v2_v5.0.uf2`. That name can't fit DOS 8.3, so Windows must write a multi-entry VFAT long-filename record onto the SAMD21 bootloader's tiny emulated FAT volume — and that minimal FAT emulation doesn't always handle it, hanging the copy. The incomplete write leaves no valid app, so the bootloader keeps re-enumerating.

## Fix

- **Build** (`build_uf2.yml`): assets are now short, 8.3-safe codes — a board code plus a digits-only `major.minor` version code, e.g. `xb2_50.uf2` (XIAO basic-PCB v2 @ v5.0). Stamping the raw tag would add a second dot and break 8.3, so a `VERCODE` is derived (`v5.0` → `50`).
- **Updater** (`script.js`): maps each selection to the new short code, with a **legacy fallback** to the old long name so it keeps working on releases not yet re-stamped (no broken window at deploy). UF2 downloads also save under a friendly `VAIL_5_0.uf2` via a Blob fetch through the existing CORS proxy (the `<a download>` filename is ignored for cross-origin GitHub links).

## Follow-up (after merge + Pages deploy)

Re-stamp existing release assets to the short names on **V5.0**, **v5.0.1-beta.1**, and **v5.2.0-momidi-beta.1** (upload short names, then delete the long ones). The updater's legacy fallback means this can be done any time after deploy with no downtime.

## Summary by Sourcery

Ensure firmware UF2 assets and downloads use short DOS 8.3-safe filenames to prevent Windows drag-to-bootloader flashing hangs while maintaining backward compatibility with existing releases.

New Features:
- Introduce short board-code-based firmware identifiers and user-facing download names that encode major.minor versions in a compact format.
- Add client-side logic to download UF2 files via a Blob-based flow so browsers save them under the new short filenames.

Enhancements:
- Update the online updater to resolve both new short firmware asset names and legacy long names so existing releases continue to work during migration.

Build:
- Change UF2 build matrix artifact names to short 8.3-safe codes and stamp them with a derived version code instead of the raw tag to keep release assets 8.3-compliant.

CI:
- Adjust the UF2 build workflow release step to compute and apply a digits-only version code when naming firmware assets.

Deployment:
- Bump the online updater script version reference in the HTML to deploy the new firmware naming and download behavior.