### PR TITLE
Keep GitHub asset filename on updater downloads

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -551,6 +551,6 @@
 
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="script.js?v=2026-06-13.1" defer></script>
+<script src="script.js?v=2026-06-13.2" defer></script>
 </body>
 </html>

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -199,27 +199,13 @@ function getFirmwareBase() {
     return { base: `${p}np`, legacyBase: `${wizardState.board}_non_pcb`, ext: 'uf2' };
 }
 
-// Build a short, DOS 8.3-safe download filename (<=8-char name + single dot +
-// 3-char extension) so Windows never has to write a VFAT long-filename entry
-// onto the SAMD21 bootloader's tiny emulated FAT volume. Long asset names like
-// "xiao_basic_pcb_v2_v5.0.uf2" can hang or fail the drag-to-bootloader copy on
-// Windows 10/11, leaving the board stuck in storage (bootloader) mode. The
-// bootloader flashes by UF2 block magic and ignores the filename, so any short
-// name works; we keep major.minor so users still recognize the version. Patch
-// and pre-release suffixes are dropped to stay within the 8-char budget.
-// e.g. "v5.0" -> "VAIL_5_0.uf2", "v5.1.0" -> "VAIL_5_1.uf2".
-function shortFirmwareName(tag, ext) {
-    const m = String(tag || '').match(/(\d+)(?:\.(\d+))?/);
-    const major = m ? m[1] : '0';
-    const minor = m && m[2] != null ? m[2] : '0';
-    return `VAIL_${major}_${minor}.${ext}`;
-}
-
 // Resolve the firmware download for the current selection + selected version.
 // Firmware comes exclusively from the selected release's tag-stamped asset.
 // .hex (Arduino Micro) is fetched in JS, so its asset URL is routed through the
-// CORS proxy; .uf2 is a direct anchor download (with a Blob-based short-name
-// fallback handled at click time — see downloadFirmwareShortName).
+// CORS proxy; .uf2 is a direct anchor download of the GitHub asset. The asset
+// names are already short and DOS 8.3-safe (e.g. xb2_50.uf2), so the downloaded
+// file keeps GitHub's exact name — which doubles as a troubleshooting label
+// (which board/variant/version was flashed) and won't hang the Windows copy.
 function getFirmwareFile() {
     const sel = getFirmwareBase();
     if (!sel) return null;
@@ -239,35 +225,7 @@ function getFirmwareFile() {
     const url = ext === 'hex'
         ? `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${adapterReleases.selected.tag_name}/${asset.name}`
         : asset.browser_download_url;
-    return { url, filename: asset.name, downloadName: shortFirmwareName(adapterReleases.selected.tag_name, ext) };
-}
-
-// Download the UF2 under its short 8.3-safe name. The <a download> filename is
-// ignored for cross-origin GitHub asset URLs, so the browser would otherwise
-// keep GitHub's long asset name. Fetch through the CORS proxy and save a Blob,
-// where the short download name IS honored. Falls back to the direct GitHub
-// link (long name, but still flashes) if the proxied fetch fails.
-async function downloadFirmwareShortName(firmwareFile) {
-    const tag = adapterReleases.selected && adapterReleases.selected.tag_name;
-    const proxyUrl = `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${tag}/${firmwareFile.filename}`;
-    const saveBlob = (href, revoke) => {
-        const a = document.createElement('a');
-        a.href = href;
-        a.download = firmwareFile.downloadName;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        if (revoke) setTimeout(() => URL.revokeObjectURL(href), 10000);
-    };
-    try {
-        const resp = await fetch(proxyUrl, { cache: 'no-cache' });
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const blob = await resp.blob();
-        saveBlob(URL.createObjectURL(blob), true);
-    } catch (err) {
-        console.log('Short-name download failed, falling back to direct link:', err.message);
-        saveBlob(firmwareFile.url, false);
-    }
+    return { url, filename: asset.name };
 }
 
 // Get friendly names for display
@@ -521,10 +479,10 @@ function updateStep3Content() {
         downloadButton.setAttribute('aria-disabled', 'true');
         downloadText.textContent = `${firmwareFile.board} not available in ${firmwareFile.version}`;
     } else if (firmwareFile) {
-        const savedName = firmwareFile.downloadName || firmwareFile.filename;
-        // href is the direct-link fallback; the click handler does a Blob
-        // download under the short 8.3 name so Windows' drag-to-bootloader copy
-        // doesn't choke on a long filename.
+        // Download the GitHub asset directly, keeping its exact (short, 8.3-safe)
+        // name so the saved file matches the release asset — useful as a
+        // troubleshooting label for which firmware was flashed.
+        const savedName = firmwareFile.filename;
         downloadButton.href = firmwareFile.url;
         downloadButton.download = savedName;
         downloadText.textContent = `Download ${savedName}`;
@@ -890,17 +848,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (this.classList.contains('disabled')) {
             event.preventDefault();
             alert("Please complete the previous steps first.");
-            return;
-        }
-        // For UF2 boards, save under a short 8.3-safe name via a Blob download
-        // so the Windows drag-to-bootloader copy doesn't hang on a long filename
-        // (which leaves the board stuck in storage mode). .hex (Micro) flashes
-        // over WebSerial on its own page, so it never uses this button.
-        const firmwareFile = getFirmwareFile();
-        if (firmwareFile && !firmwareFile.unavailable &&
-            firmwareFile.downloadName && firmwareFile.downloadName.endsWith('.uf2')) {
-            event.preventDefault();
-            downloadFirmwareShortName(firmwareFile);
         }
     });
 });


### PR DESCRIPTION
Now that release assets are short and 8.3-safe (e.g. `xb2_50.uf2`), the updater no longer needs to rename downloads to `VAIL_5_0.uf2`. Keeping GitHub's exact filename is more useful: it identifies the exact board/variant/version that was flashed — a standard troubleshooting question when a user reports an issue.

Removes the Blob/short-name download path; UF2 downloads are now a plain direct download of the GitHub asset (still short and safe to drag, no Windows long-filename hang).

## Summary by Sourcery

Simplify the firmware updater by downloading UF2 assets directly from GitHub under their original short 8.3-safe filenames.

Bug Fixes:
- Preserve GitHub UF2 asset filenames to reliably identify the exact board/variant/version flashed during troubleshooting.

Enhancements:
- Remove the custom short-filename Blob download path in favor of a direct UF2 asset download using the GitHub-provided name.