### PR TITLE
Hidden serial (SAM-BA/BOSSA) flasher fallback for SAMD21 boards

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -273,6 +273,35 @@
             </details>
         </div>
 
+        <!-- Hidden advanced fallback: flash directly over the bootloader's COM
+             port (SAM-BA / BOSSA, the same path the Arduino IDE uses), for users
+             whose UF2 drag-and-drop copy hangs on Windows. Revealed only when the
+             URL hash contains "serial" — e.g. https://update.vailadapter.com/#serial -->
+        <div id="serialFlashAdvanced" class="flash-step" style="display: none; border: 2px dashed #6a5acd; border-radius: 8px; padding: 16px; margin-top: 24px;">
+            <div class="step-header">
+                <span class="step-badge" style="background: #6a5acd;">⚡</span>
+                <h3>Advanced: Flash over COM port (UF2 not working?)</h3>
+            </div>
+            <p>If dragging the <code>.uf2</code> onto the drive hangs or never finishes, you can flash <strong>directly over the bootloader's serial port</strong> — the same method the Arduino IDE uses. This skips the file-copy step entirely. Chrome, Edge, or Opera only.</p>
+            <ol>
+                <li>Pick your firmware version and board above (same selection as the download).</li>
+                <li>Put the adapter in <strong>bootloader mode</strong> using "Enter Boot Mode" above, or double-tap the reset button. It does <em>not</em> need to show the storage drive — it just needs to be in bootloader mode.</li>
+                <li>Click <strong>Flash over serial</strong> and pick your adapter's COM port (on Windows it's usually the highest-numbered COM port that appears).</li>
+            </ol>
+            <button id="serialFlashButton" class="btn-primary">⚡ Flash over serial (COM port)</button>
+            <div class="progress-container" id="serialFlashProgressContainer" style="display: none; margin-top: 16px;">
+                <div class="progress-label" id="serialFlashProgressLabel">Preparing…</div>
+                <div style="background: #2a2a2a; border-radius: 8px; overflow: hidden; height: 20px;">
+                    <div id="serialFlashProgressBar" style="background: linear-gradient(90deg, #6a5acd, #836fff); height: 100%; width: 0%; transition: width 0.2s;"></div>
+                </div>
+                <div id="serialFlashProgressPercent" style="margin-top: 6px; font-size: 13px; color: #999;">0%</div>
+            </div>
+            <div class="log-container" style="margin-top: 16px;">
+                <h4>Serial Flash Log:</h4>
+                <pre id="serialFlashLog"></pre>
+            </div>
+        </div>
+
         <button class="btn-secondary" id="backToStep2">← Back</button>
         <button class="btn-primary" id="startOver">Start Over</button>
     </section>
@@ -551,6 +580,7 @@
 
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="script.js?v=2026-06-13.2" defer></script>
+<script src="samba-flasher.js?v=2026-06-13.3"></script>
+<script src="script.js?v=2026-06-13.3" defer></script>
 </body>
 </html>

--- a/online-updater/samba-flasher.js
+++ b/online-updater/samba-flasher.js
@@ -1,0 +1,168 @@
+// WebSerial SAM-BA / BOSSA flasher for SAMD21 boards (Seeed XIAO, Adafruit QT Py,
+// TRRS Trinkey / Vail Lite). Flashes firmware directly over the bootloader's CDC
+// serial port — the same path the Arduino IDE uses via `bossac` — bypassing the
+// UF2 mass-storage drag-and-drop entirely. This is the fallback for users whose
+// Windows UF2 copy hangs but whose bootloader still enumerates.
+//
+// Protocol (Adafruit uf2-samdx1 SAM-BA monitor, "[Arduino:XYZ]" extended set):
+//   N#                      -> binary (non-terminal) mode, replies "\n\r"
+//   V#                      -> version string, advertises [Arduino:XYZ]
+//   X<addr>#                -> erase flash from <addr> to end, replies "X\n\r"
+//   S<addr>,<size>#  <bin>  -> load <size> raw bytes into SRAM at <addr>
+//   Y<sram>,0#              -> set SRAM source buffer, replies "Y\n\r"
+//   Y<flash>,<size>#        -> copy <size> bytes SRAM->flash, replies "Y\n\r"
+//   W<addr>,<value>#        -> write 32-bit word (used to reset via AIRCR)
+// All numbers are hex; every command ends with '#'.
+
+(function () {
+    'use strict';
+
+    const FLASH_APP_ADDR = 0x2000;     // SAMD21 app start (after 8 KB bootloader)
+    const FLASH_END      = 0x40000;    // 256 KB total flash
+    const SRAM_BUFFER    = 0x20004000; // staging buffer (bossac's _user for SAMD21)
+    const CHUNK          = 0x1000;     // 4 KB per S/Y transfer (multiple of 64-byte page)
+    const AIRCR          = 0xE000ED0C; // Cortex-M Application Interrupt/Reset Control
+    const AIRCR_RESET    = 0x05FA0004; // VECTKEY | SYSRESETREQ
+
+    const hex8 = (n) => (n >>> 0).toString(16).toUpperCase().padStart(8, '0');
+
+    class SAMBAFlasher {
+        constructor({ log, progress } = {}) {
+            this.log = log || (() => {});
+            this.progress = progress || (() => {});
+            this.port = null;
+            this.reader = null;
+            this.writer = null;
+            this.rx = '';
+            this._pump = null;
+        }
+
+        async open(port, baudRate = 115200) {
+            this.port = port;
+            // Baud is irrelevant for a USB-CDC bootloader, but WebSerial requires one.
+            await port.open({ baudRate });
+            this.writer = port.writable.getWriter();
+            this.reader = port.readable.getReader();
+            this.rx = '';
+            // Background pump: append all incoming bytes (latin1) to this.rx.
+            this._pump = (async () => {
+                try {
+                    while (true) {
+                        const { value, done } = await this.reader.read();
+                        if (done) break;
+                        if (value) for (let i = 0; i < value.length; i++) this.rx += String.fromCharCode(value[i]);
+                    }
+                } catch (_) { /* reader cancelled on close */ }
+            })();
+        }
+
+        async close() {
+            try { if (this.reader) { await this.reader.cancel(); this.reader.releaseLock(); } } catch (_) {}
+            try { if (this.writer) { this.writer.releaseLock(); } } catch (_) {}
+            try { if (this.port) await this.port.close(); } catch (_) {}
+            this.reader = this.writer = this.port = null;
+        }
+
+        async _sendStr(s) { await this.writer.write(new TextEncoder().encode(s)); }
+        async _sendBytes(u8) { await this.writer.write(u8); }
+
+        // Wait until `token` appears in the receive buffer, then consume up to and
+        // including it. Throws on timeout.
+        async _waitFor(token, timeoutMs = 5000) {
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                const idx = this.rx.indexOf(token);
+                if (idx !== -1) {
+                    const out = this.rx.slice(0, idx + token.length);
+                    this.rx = this.rx.slice(idx + token.length);
+                    return out;
+                }
+                await new Promise((r) => setTimeout(r, 15));
+            }
+            throw new Error(`Timed out waiting for "${token.replace(/[\r\n]/g, '?')}" (got "${this.rx.slice(0, 64).replace(/[\r\n]/g, '?')}")`);
+        }
+
+        // Handshake: enter binary mode and confirm an Arduino XYZ bootloader.
+        async connect() {
+            this.rx = '';
+            await this._sendStr('N#');
+            try { await this._waitFor('\n\r', 1500); } catch (_) { /* some bootloaders are silent here */ }
+            await this._sendStr('V#');
+            const version = (await this._waitFor('\n\r', 3000)).trim();
+            this.log(`Bootloader: ${version}`);
+            if (!/Arduino:XYZ/i.test(version)) {
+                throw new Error('This port is not a SAMD21 Arduino-style bootloader (no [Arduino:XYZ]). Make sure you selected the bootloader COM port.');
+            }
+            return version;
+        }
+
+        async eraseApp() {
+            this.log('Erasing application flash…');
+            await this._sendStr(`X${hex8(FLASH_APP_ADDR)}#`);
+            await this._waitFor('X', 15000);
+            this.log('Erase complete.');
+        }
+
+        // Write a contiguous binary image to flash. `startAddr` is the absolute
+        // flash address of the first byte (the UF2's base, normally 0x2000).
+        async writeFirmware(bin, startAddr = FLASH_APP_ADDR) {
+            const total = bin.length;
+            let offset = 0;
+            while (offset < total) {
+                const size = Math.min(CHUNK, total - offset);
+                const chunk = bin.subarray(offset, offset + size);
+                // 1) stage the chunk in SRAM
+                await this._sendStr(`S${hex8(SRAM_BUFFER)},${hex8(size)}#`);
+                await this._sendBytes(chunk);
+                // 2) point the source buffer at the staged data
+                await this._sendStr(`Y${hex8(SRAM_BUFFER)},0#`);
+                await this._waitFor('Y', 5000);
+                // 3) copy SRAM -> flash at the absolute application address
+                await this._sendStr(`Y${hex8(startAddr + offset)},${hex8(size)}#`);
+                await this._waitFor('Y', 8000);
+                offset += size;
+                this.progress(offset, total);
+            }
+            this.log(`Wrote ${total} bytes to flash.`);
+        }
+
+        // Trigger a CPU reset so the freshly flashed app runs. The port drops as
+        // the device re-enumerates, so a write error here is expected/benign.
+        async resetDevice() {
+            this.log('Resetting device…');
+            try {
+                await this._sendStr(`W${hex8(AIRCR)},${hex8(AIRCR_RESET)}#`);
+            } catch (_) { /* port already gone — the reset took effect */ }
+        }
+    }
+
+    // Parse a UF2 file (ArrayBuffer) into a contiguous flash image + base address.
+    // Each 512-byte block carries a target address and (typically) 256 payload
+    // bytes. Gaps are filled with 0xFF (matching erased flash).
+    function uf2ToBin(arrayBuffer) {
+        const view = new DataView(arrayBuffer);
+        const blocks = [];
+        let minAddr = Infinity, maxEnd = 0;
+        for (let pos = 0; pos + 512 <= arrayBuffer.byteLength; pos += 512) {
+            const magic0 = view.getUint32(pos + 0, true);
+            const magic1 = view.getUint32(pos + 4, true);
+            const magicEnd = view.getUint32(pos + 508, true);
+            if (magic0 !== 0x0A324655 || magic1 !== 0x9E5D5157 || magicEnd !== 0x0AB16F30) continue;
+            const flags = view.getUint32(pos + 8, true);
+            const addr = view.getUint32(pos + 12, true);
+            const payloadSize = view.getUint32(pos + 16, true);
+            if (flags & 0x00000001) continue; // "not main flash" block
+            const data = new Uint8Array(arrayBuffer, pos + 32, payloadSize);
+            blocks.push({ addr, data });
+            if (addr < minAddr) minAddr = addr;
+            if (addr + payloadSize > maxEnd) maxEnd = addr + payloadSize;
+        }
+        if (!blocks.length) throw new Error('No valid UF2 blocks found in firmware file.');
+        const bin = new Uint8Array(maxEnd - minAddr).fill(0xFF);
+        for (const b of blocks) bin.set(b.data, b.addr - minAddr);
+        return { bin, baseAddr: minAddr };
+    }
+
+    window.SAMBAFlasher = SAMBAFlasher;
+    window.uf2ToBin = uf2ToBin;
+})();

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -489,6 +489,93 @@ function updateStep3Content() {
         downloadButton.classList.remove('disabled');
         downloadButton.removeAttribute('aria-disabled');
     }
+
+    maybeRevealSerialFlash();
+}
+
+// --- Advanced: SAM-BA / BOSSA serial flashing for SAMD21 boards -------------
+// Hidden fallback (revealed when the URL hash contains "serial") for users whose
+// UF2 drag-and-drop copy hangs on Windows. Flashes the selected release's .uf2
+// directly over the bootloader's COM port — fetched via the CORS proxy and
+// converted to a raw binary — the same path the Arduino IDE uses via bossac.
+
+function serialFlashLog(message) {
+    console.log('[samba]', message);
+    const el = document.getElementById('serialFlashLog');
+    if (el) { el.textContent += message + '\n'; el.scrollTop = el.scrollHeight; }
+}
+
+// Show the advanced serial-flash panel only when the URL hash opts in.
+function maybeRevealSerialFlash() {
+    const panel = document.getElementById('serialFlashAdvanced');
+    if (panel) panel.style.display = /serial|advanced/i.test(location.hash) ? 'block' : 'none';
+}
+
+async function flashAdapterOverSerial() {
+    if (!('serial' in navigator)) {
+        alert('WebSerial is not supported. Please use Chrome, Edge, or Opera.');
+        return;
+    }
+    const firmware = getFirmwareFile();
+    if (!firmware || firmware.unavailable) {
+        alert('Select a firmware version and board above first.');
+        return;
+    }
+    if (!firmware.filename.toLowerCase().endsWith('.uf2')) {
+        alert('Serial flashing applies to the SAMD21 boards (UF2). The Arduino Micro has its own flasher.');
+        return;
+    }
+
+    const tag = adapterReleases.selected && adapterReleases.selected.tag_name;
+    const proxyUrl = `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${tag}/${firmware.filename}`;
+
+    const container = document.getElementById('serialFlashProgressContainer');
+    const bar = document.getElementById('serialFlashProgressBar');
+    const label = document.getElementById('serialFlashProgressLabel');
+    const percent = document.getElementById('serialFlashProgressPercent');
+
+    let flasher = null;
+    try {
+        serialFlashLog(`Downloading ${firmware.filename}…`);
+        const resp = await fetch(proxyUrl, { cache: 'no-cache' });
+        if (!resp.ok) throw new Error(`Firmware download failed: HTTP ${resp.status}`);
+        const { bin, baseAddr } = window.uf2ToBin(await resp.arrayBuffer());
+        serialFlashLog(`Firmware ready: ${bin.length} bytes @ 0x${baseAddr.toString(16)}.`);
+
+        serialFlashLog("Select your adapter's bootloader COM port…");
+        const port = await navigator.serial.requestPort();
+
+        if (container) container.style.display = 'block';
+        if (label) label.textContent = 'Connecting to bootloader…';
+
+        flasher = new window.SAMBAFlasher({
+            log: serialFlashLog,
+            progress: (cur, total) => {
+                const pct = Math.round((cur / total) * 100);
+                if (bar) bar.style.width = pct + '%';
+                if (percent) percent.textContent = `${pct}% (${cur}/${total} bytes)`;
+                if (label) label.textContent = 'Writing firmware…';
+            },
+        });
+
+        await flasher.open(port);
+        await flasher.connect();
+        await flasher.eraseApp();
+        await flasher.writeFirmware(bin, baseAddr);
+        await flasher.resetDevice();
+
+        if (label) label.textContent = '✅ Done';
+        if (percent) percent.textContent = '100%';
+        if (bar) bar.style.width = '100%';
+        serialFlashLog('✅ Flash complete. The adapter should reboot into the new firmware.');
+        alert('Firmware flashed over serial! The adapter will reboot. If it stays in bootloader mode, unplug and replug it.');
+    } catch (err) {
+        serialFlashLog(`❌ ${err.message}`);
+        if (label) label.textContent = '❌ Error';
+        if (err.name !== 'NotFoundError') alert(`Serial flash failed: ${err.message}`);
+    } finally {
+        if (flasher) { try { await flasher.close(); } catch (e) { /* ignore */ } }
+    }
 }
 
 // WebSerial boot mode functionality
@@ -827,6 +914,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Boot mode button
     document.getElementById('bootModeButton')?.addEventListener('click', triggerBootloaderViaWebSerial);
+
+    // Advanced serial (SAM-BA) flashing — hidden unless the URL hash opts in.
+    document.getElementById('serialFlashButton')?.addEventListener('click', flashAdapterOverSerial);
+    window.addEventListener('hashchange', maybeRevealSerialFlash);
+    maybeRevealSerialFlash();
 
     // Arduino Micro (WebSerial AVR109) buttons
     document.getElementById('microBootModeButton')?.addEventListener('click', triggerMicroBootloader);


### PR DESCRIPTION
## Why
For users whose UF2 drag-and-drop copy hangs on Windows (the long-filename FAT issue, and other Windows copy quirks), this adds a **browser serial flasher** that writes firmware directly over the bootloader's COM port — the same path the Arduino IDE uses via `bossac`. It bypasses the UF2 mass-storage layer entirely.

## What
- **`samba-flasher.js`** — a WebSerial SAM-BA client for the SAMD21 Arduino-style bootloader (XIAO, QT Py, Vail Lite). Uses the extended `[Arduino:XYZ]` command set confirmed from the Adafruit `uf2-samdx1` source: `N`/`V` handshake, `X` erase-to-end, `S`+binary to stage in SRAM (`0x20004000`), `Y`/`Y` copy SRAM→flash, `W` AIRCR reset. Includes a UF2→raw-bin parser.
- **`script.js`** — reuses the existing release/board selection, fetches the `.uf2` through the CORS proxy (direct GitHub fetch is cross-origin-blocked), converts to bin, and drives the flasher with a progress bar + log.
- **`index.html`** — a *somewhat hidden* panel on the flash step, shown only when the URL hash contains `serial` (e.g. `update.vailadapter.com/#serial`). Normal users never see it.

## Testing
Needs hardware (a SAMD21 adapter in bootloader mode). It has not yet been run against a device — first hardware test pending.

## Summary by Sourcery

Add a hidden WebSerial-based SAM-BA/BOSSA flashing fallback for SAMD21-based boards that flashes UF2 firmware directly over the bootloader COM port when enabled via URL hash.

New Features:
- Introduce a WebSerial SAM-BA flasher implementation for SAMD21 boards that converts UF2 firmware to raw binary and programs it over the bootloader serial port.
- Expose an advanced, hash-gated UI panel that guides users through flashing over the COM port with progress and logging when UF2 drag-and-drop fails.

Enhancements:
- Wire the new SAM-BA flasher into the existing updater flow, including firmware selection, CORS-proxied download, and progress updates, while keeping it hidden for normal users.