### PR TITLE
Add test-only 'erase app' button to serial flasher panel

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -289,6 +289,12 @@
                 <li>Click <strong>Flash over serial</strong> and pick your adapter's COM port (on Windows it's usually the highest-numbered COM port that appears).</li>
             </ol>
             <button id="serialFlashButton" class="btn-primary">⚡ Flash over serial (COM port)</button>
+
+            <div style="margin-top: 14px; padding-top: 12px; border-top: 1px solid #444;">
+                <p style="font-size: 13px; color: #b0a0e0; margin: 0 0 8px;"><strong>Testing tool:</strong> erase the firmware to reproduce the "stuck in bootloader" state. The device will boot to storage mode every time until you reflash it (recoverable — the bootloader is never touched).</p>
+                <button id="serialEraseButton" class="btn-secondary" style="border-color: #b5651d; color: #ffb27a;">🧪 Erase app (simulate stuck state)</button>
+            </div>
+
             <div class="progress-container" id="serialFlashProgressContainer" style="display: none; margin-top: 16px;">
                 <div class="progress-label" id="serialFlashProgressLabel">Preparing…</div>
                 <div style="background: #2a2a2a; border-radius: 8px; overflow: hidden; height: 20px;">
@@ -581,6 +587,6 @@
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
 <script src="samba-flasher.js?v=2026-06-13.3"></script>
-<script src="script.js?v=2026-06-13.3" defer></script>
+<script src="script.js?v=2026-06-13.4" defer></script>
 </body>
 </html>

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -578,6 +578,37 @@ async function flashAdapterOverSerial() {
     }
 }
 
+// Testing helper: erase just the app region so the bootloader finds no valid
+// app and stays in storage/bootloader mode on every power-up — i.e. reproduce
+// the "stuck" state on purpose. Fully recoverable: the bootloader (0x0000-0x2000)
+// is never erased, so "Flash over serial" or UF2 brings it back.
+async function eraseAdapterAppForTest() {
+    if (!('serial' in navigator)) {
+        alert('WebSerial is not supported. Please use Chrome, Edge, or Opera.');
+        return;
+    }
+    if (!confirm('TEST ONLY: this erases the adapter\'s firmware so it boots into bootloader (storage) mode every time — reproducing the "stuck" state. You can recover it with "Flash over serial" or UF2. Continue?')) {
+        return;
+    }
+    let flasher = null;
+    try {
+        serialFlashLog("Select your adapter's bootloader COM port…");
+        const port = await navigator.serial.requestPort();
+        flasher = new window.SAMBAFlasher({ log: serialFlashLog });
+        await flasher.open(port);
+        await flasher.connect();
+        await flasher.eraseApp();
+        await flasher.resetDevice();
+        serialFlashLog('✅ App erased. The adapter will now boot into bootloader mode on every plug-in until you reflash it.');
+        alert('App erased — the adapter is now in the "stuck" state (boots to bootloader/storage mode every time). Use "Flash over serial" or UF2 to recover it.');
+    } catch (err) {
+        serialFlashLog(`❌ ${err.message}`);
+        if (err.name !== 'NotFoundError') alert(`Erase failed: ${err.message}`);
+    } finally {
+        if (flasher) { try { await flasher.close(); } catch (e) { /* ignore */ } }
+    }
+}
+
 // WebSerial boot mode functionality
 let port;
 
@@ -917,6 +948,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Advanced serial (SAM-BA) flashing — hidden unless the URL hash opts in.
     document.getElementById('serialFlashButton')?.addEventListener('click', flashAdapterOverSerial);
+    document.getElementById('serialEraseButton')?.addEventListener('click', eraseAdapterAppForTest);
     window.addEventListener('hashchange', maybeRevealSerialFlash);
     maybeRevealSerialFlash();
 


### PR DESCRIPTION
Adds a one-click **Erase app (simulate stuck state)** button to the hidden `#serial` panel so the stuck-in-bootloader state can be reproduced on demand for testing the serial flasher.

It sends only the SAM-BA `X` erase-to-end command at `0x2000`, so the bootloader (`0x0000–0x2000`) is untouched and the device stays recoverable — it just boots to storage mode every time until reflashed. Guarded by a `confirm()`.

## Summary by Sourcery

Add a serial flasher testing helper that erases only the adapter firmware region to intentionally reproduce the stuck-in-bootloader state while keeping the device recoverable.

New Features:
- Introduce a test-only WebSerial action that erases the adapter app region and leaves the bootloader intact to simulate a persistent bootloader/storage mode state.

Enhancements:
- Expose the new erase-app test action as a button in the advanced serial flashing panel with explanatory UI copy.
- Bump the online updater script version to ensure clients load the updated JavaScript.