### PR TITLE
Make SAM-BA handshake robust; clearer no-response error

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -586,7 +586,7 @@
 
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="samba-flasher.js?v=2026-06-13.3"></script>
-<script src="script.js?v=2026-06-13.4" defer></script>
+<script src="samba-flasher.js?v=2026-06-13.5"></script>
+<script src="script.js?v=2026-06-13.5" defer></script>
 </body>
 </html>

--- a/online-updater/samba-flasher.js
+++ b/online-updater/samba-flasher.js
@@ -82,22 +82,44 @@
             throw new Error(`Timed out waiting for "${token.replace(/[\r\n]/g, '?')}" (got "${this.rx.slice(0, 64).replace(/[\r\n]/g, '?')}")`);
         }
 
-        // Handshake: enter binary mode and confirm an Arduino XYZ bootloader.
+        // Handshake: enter binary mode and read the bootloader version. Retries
+        // because the first bytes after a CDC port opens are often dropped.
         async connect() {
+            // Raise DTR/RTS — some WebSerial + USB-CDC combos won't deliver RX
+            // bytes until DTR is asserted. Harmless on the bootloader.
+            try { await this.port.setSignals({ dataTerminalReady: true, requestToSend: true }); } catch (_) {}
+
+            let version = '';
+            for (let attempt = 1; attempt <= 5 && !version; attempt++) {
+                this.rx = '';
+                await this._sendStr('N#');           // exit terminal mode
+                await new Promise((r) => setTimeout(r, 120));
+                await this._sendStr('V#');           // request version
+                try {
+                    await this._waitFor('\n', 1200); // any newline = a line arrived
+                    await new Promise((r) => setTimeout(r, 150)); // let the rest land
+                    version = (this.rx || '').replace(/[\r\n]/g, ' ').trim();
+                } catch (_) {
+                    this.log(`No bootloader response yet (attempt ${attempt}/5)…`);
+                }
+            }
             this.rx = '';
-            await this._sendStr('N#');
-            try { await this._waitFor('\n\r', 1500); } catch (_) { /* some bootloaders are silent here */ }
-            await this._sendStr('V#');
-            const version = (await this._waitFor('\n\r', 3000)).trim();
+
+            if (!version) {
+                throw new Error('No response from the bootloader. Make sure the adapter is in BOOTLOADER mode (double-tap the reset button — a drive like XIAOBOOT/QTPYBOOT/ADAPTERBOOT should appear) and that you picked THAT device\'s COM port.');
+            }
             this.log(`Bootloader: ${version}`);
             if (!/Arduino:XYZ/i.test(version)) {
-                throw new Error('This port is not a SAMD21 Arduino-style bootloader (no [Arduino:XYZ]). Make sure you selected the bootloader COM port.');
+                // Don't hard-fail: try the extended X/Y commands anyway and let
+                // the erase/write step surface a real failure if they're absent.
+                this.log('⚠️ Bootloader did not advertise [Arduino:XYZ]; trying extended commands anyway.');
             }
             return version;
         }
 
         async eraseApp() {
             this.log('Erasing application flash…');
+            this.rx = '';
             await this._sendStr(`X${hex8(FLASH_APP_ADDR)}#`);
             await this._waitFor('X', 15000);
             this.log('Erase complete.');


### PR DESCRIPTION
First hardware test of the serial flasher returned 'no response' from the bootloader (timed out with an empty buffer). Hardens `connect()`: assert DTR/RTS on open, retry the N/V handshake up to 5x, accept either newline order, don't hard-fail when `[Arduino:XYZ]` is absent (warn + try anyway), and replace the cryptic timeout with a clear 'put it in bootloader mode and pick that COM port' message. Also clears the RX buffer before erase.

## Summary by Sourcery

Improve reliability and user feedback of the SAM-BA bootloader handshake in the web-based flasher.

Bug Fixes:
- Make the SAM-BA bootloader connection more robust by retrying the version handshake and handling dropped bytes when the serial port opens.
- Prevent stale serial data from interfering with flash erasure by clearing the RX buffer before issuing the erase command.

Enhancements:
- Assert DTR/RTS on serial port open, tolerate either newline ordering, and continue even if the bootloader does not advertise [Arduino:XYZ], logging a warning instead.
- Replace the generic bootloader timeout error with clearer guidance on entering bootloader mode and selecting the correct COM port.

Build:
- Bump cache-busting version query parameters for the SAM-BA flasher and main script in the HTML entry point.