### PR TITLE
Redesign flash step: method chooser + clean per-method flows

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -137,6 +137,69 @@
         <button class="btn-secondary" id="backToStep1">← Back</button>
     </section>
 
+    <!-- Step 2.5: Choose firmware version + flashing method -->
+    <section id="stepMethod" class="wizard-step">
+        <h2>Set up your update</h2>
+        <p class="step-description">You've selected: <strong id="selectedConfigMethod"></strong></p>
+
+        <!-- Pick version -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">1</span>
+                <h3>Pick a firmware version</h3>
+            </div>
+            <p>The latest stable release is selected by default.</p>
+            <div class="version-selector-container">
+                <div class="version-selector-row">
+                    <select id="adapterVersionSelect" class="version-select" disabled>
+                        <option value="">Loading releases…</option>
+                    </select>
+                    <label class="test-release-toggle">
+                        <input type="checkbox" id="adapterShowTestRelease">
+                        <span class="toggle-label">Show test release</span>
+                    </label>
+                </div>
+                <div id="adapterTestReleaseWarning" class="test-release-warning" style="display: none;">
+                    <strong>Warning:</strong> Test releases may not be stable and could contain bugs. They include features currently being developed. Use at your own risk.
+                </div>
+                <div id="adapterReleaseInfo" class="release-info" style="display: none;">
+                    <div class="release-info-header">
+                        <span id="adapterReleaseVersionBadge" class="firmware-version"></span>
+                        <span id="adapterReleaseDate" class="release-date"></span>
+                    </div>
+                    <div id="adapterReleaseNotes" class="release-notes"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Pick method -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">2</span>
+                <h3>Choose how to flash</h3>
+            </div>
+            <p>Two ways to get the firmware onto your adapter. <strong>Not sure? Use the UF2 file method</strong> — it's the simplest and works almost everywhere.</p>
+
+            <div class="card-grid">
+                <div class="selection-card" data-method="uf2">
+                    <div class="card-icon">📄</div>
+                    <h3>UF2 file <span style="font-size: 12px; color: #4CAF50; font-weight: 600;">★ Recommended</span></h3>
+                    <p>Download a small file and drag it onto a drive that pops up. No special browser needed for the copy.</p>
+                    <div class="hint">✅ Works on Windows, macOS, Linux, ChromeOS — and even a phone. Best for most people.</div>
+                </div>
+
+                <div class="selection-card" data-method="serial">
+                    <div class="card-icon">🔌</div>
+                    <h3>Web flasher <span style="font-size: 12px; color: #b388ff; font-weight: 600;">BETA</span></h3>
+                    <p>Flashes straight over the USB port from your browser — nothing to download or drag.</p>
+                    <div class="hint">💡 Try this if the UF2 copy stalls or you'd rather not handle files. Requires <strong>Chrome, Edge, or Opera on a computer</strong> (not Safari, Firefox, or phones).</div>
+                </div>
+            </div>
+        </div>
+
+        <button class="btn-secondary" id="backToBoardFromMethod">← Back</button>
+    </section>
+
     <!-- Step 3: Flash Adapter Firmware (UF2) -->
     <section id="step3" class="wizard-step">
         <h2>Flash Your Firmware</h2>
@@ -181,35 +244,9 @@
         <div class="flash-step">
             <div class="step-header">
                 <span class="step-badge">3</span>
-                <h3>Download Firmware</h3>
+                <h3>Download the Firmware File</h3>
             </div>
-            <p>Choose which firmware version to flash. The latest stable release is selected by default.</p>
-
-            <div class="version-selector-container">
-                <div class="version-selector-row">
-                    <select id="adapterVersionSelect" class="version-select" disabled>
-                        <option value="">Loading releases…</option>
-                    </select>
-                    <label class="test-release-toggle">
-                        <input type="checkbox" id="adapterShowTestRelease">
-                        <span class="toggle-label">Show test release</span>
-                    </label>
-                </div>
-
-                <div id="adapterTestReleaseWarning" class="test-release-warning" style="display: none;">
-                    <strong>Warning:</strong> Test releases may not be stable and could contain bugs. They include features currently being developed. Use at your own risk.
-                </div>
-
-                <div id="adapterReleaseInfo" class="release-info" style="display: none;">
-                    <div class="release-info-header">
-                        <span id="adapterReleaseVersionBadge" class="firmware-version"></span>
-                        <span id="adapterReleaseDate" class="release-date"></span>
-                    </div>
-                    <div id="adapterReleaseNotes" class="release-notes"></div>
-                </div>
-            </div>
-
-            <p style="margin-top: 16px;">Download the firmware file for your configuration:</p>
+            <p>This is the firmware version you picked on the previous screen — <strong id="uf2VersionLabel">the selected release</strong>.</p>
             <a href="#" id="downloadButton" class="btn-download disabled" role="button" aria-disabled="true">
                 <span class="download-icon">⬇️</span>
                 <span id="downloadText">Download UF2 File</span>
@@ -273,27 +310,51 @@
             </details>
         </div>
 
-        <!-- Hidden advanced fallback: flash directly over the bootloader's COM
-             port (SAM-BA / BOSSA, the same path the Arduino IDE uses), for users
-             whose UF2 drag-and-drop copy hangs on Windows. Revealed only when the
-             URL hash contains "serial" — e.g. https://update.vailadapter.com/#serial -->
-        <div id="serialFlashAdvanced" class="flash-step" style="display: none; border: 2px dashed #6a5acd; border-radius: 8px; padding: 16px; margin-top: 24px;">
-            <div class="step-header">
-                <span class="step-badge" style="background: #6a5acd;">⚡</span>
-                <h3>Advanced: Flash over COM port (UF2 not working?)</h3>
-            </div>
-            <p>If dragging the <code>.uf2</code> onto the drive hangs or never finishes, you can flash <strong>directly over the bootloader's serial port</strong> — the same method the Arduino IDE uses. This skips the file-copy step entirely. Chrome, Edge, or Opera only.</p>
-            <ol>
-                <li>Pick your firmware version and board above (same selection as the download).</li>
-                <li>Put the adapter in <strong>bootloader mode</strong> using "Enter Boot Mode" above, or double-tap the reset button. It does <em>not</em> need to show the storage drive — it just needs to be in bootloader mode.</li>
-                <li>Click <strong>Flash over serial</strong> and pick your adapter's COM port (on Windows it's usually the highest-numbered COM port that appears).</li>
-            </ol>
-            <button id="serialFlashButton" class="btn-primary">⚡ Flash over serial (COM port)</button>
+        <button class="btn-secondary" id="backToMethodFromUf2">← Back</button>
+        <button class="btn-primary" id="startOver">Start Over</button>
+    </section>
 
-            <div style="margin-top: 14px; padding-top: 12px; border-top: 1px solid #444;">
-                <p style="font-size: 13px; color: #b0a0e0; margin: 0 0 8px;"><strong>Testing tool:</strong> erase the firmware to reproduce the "stuck in bootloader" state. The device will boot to storage mode every time until you reflash it (recoverable — the bootloader is never touched).</p>
-                <button id="serialEraseButton" class="btn-secondary" style="border-color: #b5651d; color: #ffb27a;">🧪 Erase app (simulate stuck state)</button>
+    <!-- Step 3 (Serial / Web flasher variant): SAM-BA over WebSerial -->
+    <section id="stepSerial" class="wizard-step">
+        <h2>Flash Over USB (Web Flasher)</h2>
+        <p class="step-description">You've selected: <strong id="selectedConfigSerial"></strong></p>
+
+        <div class="warning-box" style="background: linear-gradient(135deg, #2a2350 0%, #3a3066 100%); border: 2px solid #b388ff; border-radius: 8px; padding: 14px; margin-bottom: 20px;">
+            <strong style="color: #d0b3ff;">Beta feature.</strong> Requires <strong>Chrome, Edge, or Opera on a computer</strong> (not Safari, Firefox, or phones). Flashes directly over the USB port — no file to download or drag. If it doesn't work, go back and use the UF2 file method.
+        </div>
+
+        <!-- Sub-step 1: Plug in -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">1</span>
+                <h3>Plug In Your Adapter</h3>
             </div>
+            <p>Connect the adapter with a USB cable that supports data transfer.</p>
+        </div>
+
+        <!-- Sub-step 2: Enter bootloader -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">2</span>
+                <h3>Enter Bootloader Mode</h3>
+            </div>
+            <p><strong>Double-tap the reset button</strong> on your adapter — a USB drive named "QTPYBOOT", "XIAOBOOT", or "ADAPTERBOOT" should appear. (If your adapter is already stuck in this mode, you're ready.)</p>
+            <p style="margin-top: 10px;">Or click below to trigger it automatically:</p>
+            <button id="serialBootButton" class="btn-primary">🔌 Enter Bootloader via WebSerial</button>
+            <div class="log-container" style="margin-top: 12px;">
+                <h4>Activity Log:</h4>
+                <pre id="serialBootLog"></pre>
+            </div>
+        </div>
+
+        <!-- Sub-step 3: Flash -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">3</span>
+                <h3>Flash the Firmware</h3>
+            </div>
+            <p>Click below and pick your adapter's <strong>COM port</strong> (on Windows it's usually the highest-numbered COM port that appears when the bootloader is active). The firmware writes directly over the connection.</p>
+            <button id="serialFlashButton" class="btn-primary">⚡ Flash Firmware Over Serial</button>
 
             <div class="progress-container" id="serialFlashProgressContainer" style="display: none; margin-top: 16px;">
                 <div class="progress-label" id="serialFlashProgressLabel">Preparing…</div>
@@ -303,13 +364,34 @@
                 <div id="serialFlashProgressPercent" style="margin-top: 6px; font-size: 13px; color: #999;">0%</div>
             </div>
             <div class="log-container" style="margin-top: 16px;">
-                <h4>Serial Flash Log:</h4>
+                <h4>Flash Log:</h4>
                 <pre id="serialFlashLog"></pre>
+            </div>
+
+            <!-- Test-only: revealed when the URL hash contains "test" -->
+            <div id="serialEraseTest" style="display: none; margin-top: 14px; padding-top: 12px; border-top: 1px solid #444;">
+                <p style="font-size: 13px; color: #b0a0e0; margin: 0 0 8px;"><strong>Testing tool:</strong> erase the firmware to reproduce the "stuck in bootloader" state (recoverable — the bootloader is never touched).</p>
+                <button id="serialEraseButton" class="btn-secondary" style="border-color: #b5651d; color: #ffb27a;">🧪 Erase app (simulate stuck state)</button>
             </div>
         </div>
 
-        <button class="btn-secondary" id="backToStep2">← Back</button>
-        <button class="btn-primary" id="startOver">Start Over</button>
+        <!-- Sub-step 4: Finalize -->
+        <div class="flash-step">
+            <div class="step-header">
+                <span class="step-badge">4</span>
+                <h3>Finalize Setup</h3>
+            </div>
+            <ol>
+                <li>The adapter reboots into the new firmware automatically (unplug/replug if it stays in bootloader mode)</li>
+                <li>Visit <a href="https://vailmorse.com" target="_blank">vailmorse.com</a> to configure your keyer type, speed, and tone</li>
+            </ol>
+            <div class="success-message">
+                <strong>✅ Done!</strong> Your Vail Adapter is running the new firmware.
+            </div>
+        </div>
+
+        <button class="btn-secondary" id="backToMethodFromSerial">← Back</button>
+        <button class="btn-primary" id="startOverFromSerial">Start Over</button>
     </section>
 
     <!-- Step 3 (Micro variant): WebSerial AVR109 flash flow -->
@@ -587,6 +669,6 @@
 <script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
 <script src="samba-flasher.js?v=2026-06-13.5"></script>
-<script src="script.js?v=2026-06-13.5" defer></script>
+<script src="script.js?v=2026-06-13.6" defer></script>
 </body>
 </html>

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -255,28 +255,30 @@ function goToStep(stepNumber) {
         step.classList.remove('active');
     });
 
-    // Show target step
+    // Show target step. Some steps map to non-numeric section ids and all of
+    // the "Update" screens (method chooser, UF2 flow, serial flow, micro flow)
+    // light up progress dot 3.
     let targetStepId = `step${stepNumber}`;
-
-    // Handle step 1.5 (adapter model selection)
-    if (stepNumber === 1.5) {
-        targetStepId = 'step1_5';
-    }
-
-    // Handle step 3.1 (Arduino Micro WebSerial flasher)
-    if (stepNumber === 3.1) {
-        targetStepId = 'step3_micro';
-    }
+    let progressStep = stepNumber;
+    if (stepNumber === 1.5) { targetStepId = 'step1_5'; }
+    else if (stepNumber === 2.5) { targetStepId = 'stepMethod'; progressStep = 3; }
+    else if (stepNumber === 3.1) { targetStepId = 'step3_micro'; progressStep = 3; }
+    else if (stepNumber === 3.2) { targetStepId = 'stepSerial'; progressStep = 3; }
 
     const targetStep = document.getElementById(targetStepId);
     if (targetStep) {
         targetStep.classList.add('active');
         wizardState.currentStep = stepNumber;
-        updateProgressBar(stepNumber);
+        updateProgressBar(progressStep);
 
         // Update step 2 content if navigating there
         if (stepNumber === 2) {
             updateStep2Content();
+        }
+
+        // Method chooser
+        if (stepNumber === 2.5) {
+            updateMethodContent();
         }
 
         // Update step 3 content if navigating there
@@ -287,6 +289,11 @@ function goToStep(stepNumber) {
         // Update Micro step content if navigating there
         if (stepNumber === 3.1) {
             updateStep3MicroContent();
+        }
+
+        // Serial (web flasher) flow
+        if (stepNumber === 3.2) {
+            updateStepSerialContent();
         }
 
         // Initialize ESP flasher if navigating to step 4 (Summit)
@@ -455,16 +462,37 @@ async function flashMicroFirmware() {
     }
 }
 
+// Human-readable description of the current model/board selection.
+function getConfigText() {
+    if (wizardState.model === 'vail_lite') return getModelName(wizardState.model);
+    return `${getModelName(wizardState.model)} + ${getBoardName(wizardState.board)}`;
+}
+
+// Label for the currently selected release (or empty until releases load).
+function getSelectedVersionLabel() {
+    const r = adapterReleases.selected;
+    return r ? (r.name || r.tag_name) : 'the selected release';
+}
+
+// Method chooser: just reflect the current selection.
+function updateMethodContent() {
+    const el = document.getElementById('selectedConfigMethod');
+    if (el) el.textContent = getConfigText();
+}
+
+// Serial (web flasher) flow: reflect selection and reveal the test-only erase
+// tool when the URL hash opts in.
+function updateStepSerialContent() {
+    const el = document.getElementById('selectedConfigSerial');
+    if (el) el.textContent = `${getConfigText()} — ${getSelectedVersionLabel()}`;
+    maybeRevealEraseTest();
+}
+
 function updateStep3Content() {
-    // Update selected configuration display
-    let configText;
-    if (wizardState.model === 'vail_lite') {
-        // Vail Lite only has one variant, no need to show board
-        configText = getModelName(wizardState.model);
-    } else {
-        configText = `${getModelName(wizardState.model)} + ${getBoardName(wizardState.board)}`;
-    }
-    document.getElementById('selectedConfig').textContent = configText;
+    const cfg = document.getElementById('selectedConfig');
+    if (cfg) cfg.textContent = getConfigText();
+    const ver = document.getElementById('uf2VersionLabel');
+    if (ver) ver.textContent = getSelectedVersionLabel();
 
     // Update download button
     const downloadButton = document.getElementById('downloadButton');
@@ -489,15 +517,13 @@ function updateStep3Content() {
         downloadButton.classList.remove('disabled');
         downloadButton.removeAttribute('aria-disabled');
     }
-
-    maybeRevealSerialFlash();
 }
 
-// --- Advanced: SAM-BA / BOSSA serial flashing for SAMD21 boards -------------
-// Hidden fallback (revealed when the URL hash contains "serial") for users whose
-// UF2 drag-and-drop copy hangs on Windows. Flashes the selected release's .uf2
-// directly over the bootloader's COM port — fetched via the CORS proxy and
-// converted to a raw binary — the same path the Arduino IDE uses via bossac.
+// --- Web flasher: SAM-BA / BOSSA serial flashing for SAMD21 boards ----------
+// The "Web flasher" method chosen on the method screen. Flashes the selected
+// release's .uf2 directly over the bootloader's COM port — fetched via the CORS
+// proxy and converted to a raw binary — the same path the Arduino IDE uses via
+// bossac. Bypasses the UF2 drag-and-drop, which can hang on Windows.
 
 function serialFlashLog(message) {
     console.log('[samba]', message);
@@ -505,10 +531,10 @@ function serialFlashLog(message) {
     if (el) { el.textContent += message + '\n'; el.scrollTop = el.scrollHeight; }
 }
 
-// Show the advanced serial-flash panel only when the URL hash opts in.
-function maybeRevealSerialFlash() {
-    const panel = document.getElementById('serialFlashAdvanced');
-    if (panel) panel.style.display = /serial|advanced/i.test(location.hash) ? 'block' : 'none';
+// The "Erase app" tool is test-only — reveal it only when the URL hash opts in.
+function maybeRevealEraseTest() {
+    const el = document.getElementById('serialEraseTest');
+    if (el) el.style.display = /test|erase|debug/i.test(location.hash) ? 'block' : 'none';
 }
 
 async function flashAdapterOverSerial() {
@@ -612,9 +638,13 @@ async function eraseAdapterAppForTest() {
 // WebSerial boot mode functionality
 let port;
 
+// Which <pre> the bootloader-trigger logs to. The UF2 flow uses #serialLog; the
+// web-flasher flow uses #serialBootLog. Set by each boot button before calling.
+let bootLogTargetId = 'serialLog';
+
 function logToPage(message) {
     console.log(message);
-    const logArea = document.getElementById('serialLog');
+    const logArea = document.getElementById(bootLogTargetId);
     if (logArea) {
         logArea.textContent += message + '\n';
         logArea.scrollTop = logArea.scrollHeight;
@@ -865,7 +895,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (wizardState.model === 'vail_lite') {
                 wizardState.board = 'trinkey'; // Set board for internal tracking
                 setTimeout(() => {
-                    goToStep(3); // Go directly to firmware flash step
+                    goToStep(2.5); // Go to the flashing-method chooser
                 }, 300);
             } else {
                 // Other models need board selection
@@ -888,10 +918,23 @@ document.addEventListener('DOMContentLoaded', () => {
             card.classList.add('selected');
             wizardState.board = card.dataset.board;
 
-            // Arduino Micro uses a different flash flow (WebSerial AVR109, not UF2)
-            const nextStep = wizardState.board === 'micro' ? 3.1 : 3;
+            // Arduino Micro has its own serial-only flow; SAMD21 boards go to
+            // the flashing-method chooser (UF2 vs web flasher).
+            const nextStep = wizardState.board === 'micro' ? 3.1 : 2.5;
             setTimeout(() => {
                 goToStep(nextStep);
+            }, 300);
+        });
+    });
+
+    // Method chooser: UF2 vs web flasher
+    document.querySelectorAll('#stepMethod .selection-card').forEach(card => {
+        card.addEventListener('click', () => {
+            document.querySelectorAll('#stepMethod .selection-card').forEach(c => c.classList.remove('selected'));
+            card.classList.add('selected');
+            wizardState.flashMethod = card.dataset.method;
+            setTimeout(() => {
+                goToStep(wizardState.flashMethod === 'serial' ? 3.2 : 3);
             }, 300);
         });
     });
@@ -906,14 +949,14 @@ document.addEventListener('DOMContentLoaded', () => {
         goToStep(1.5);
     });
 
-    document.getElementById('backToStep2')?.addEventListener('click', () => {
-        // If user selected Vail Lite, skip board selection step when going back
-        if (wizardState.model === 'vail_lite') {
-            goToStep(1.5); // Go back to model selection
-        } else {
-            goToStep(2); // Go back to board selection
-        }
+    // Method chooser back → board selection (or model, for Vail Lite which skips it)
+    document.getElementById('backToBoardFromMethod')?.addEventListener('click', () => {
+        goToStep(wizardState.model === 'vail_lite' ? 1.5 : 2);
     });
+
+    // Both flow screens go back to the method chooser
+    document.getElementById('backToMethodFromUf2')?.addEventListener('click', () => goToStep(2.5));
+    document.getElementById('backToMethodFromSerial')?.addEventListener('click', () => goToStep(2.5));
 
     document.getElementById('backToStep1FromSummit')?.addEventListener('click', () => {
         hideWhatsNew();
@@ -943,14 +986,29 @@ document.addEventListener('DOMContentLoaded', () => {
         goToStep(1);
     });
 
-    // Boot mode button
-    document.getElementById('bootModeButton')?.addEventListener('click', triggerBootloaderViaWebSerial);
+    // Boot mode buttons (UF2 flow logs to #serialLog; serial flow to #serialBootLog)
+    document.getElementById('bootModeButton')?.addEventListener('click', () => {
+        bootLogTargetId = 'serialLog';
+        triggerBootloaderViaWebSerial();
+    });
+    document.getElementById('serialBootButton')?.addEventListener('click', () => {
+        bootLogTargetId = 'serialBootLog';
+        triggerBootloaderViaWebSerial();
+    });
 
-    // Advanced serial (SAM-BA) flashing — hidden unless the URL hash opts in.
+    // Web flasher (serial) flow
     document.getElementById('serialFlashButton')?.addEventListener('click', flashAdapterOverSerial);
     document.getElementById('serialEraseButton')?.addEventListener('click', eraseAdapterAppForTest);
-    window.addEventListener('hashchange', maybeRevealSerialFlash);
-    maybeRevealSerialFlash();
+    document.getElementById('startOverFromSerial')?.addEventListener('click', () => {
+        wizardState.device = null;
+        wizardState.model = null;
+        wizardState.board = null;
+        document.querySelectorAll('.selection-card').forEach(card => card.classList.remove('selected'));
+        hideWhatsNew();
+        goToStep(1);
+    });
+    window.addEventListener('hashchange', maybeRevealEraseTest);
+    maybeRevealEraseTest();
 
     // Arduino Micro (WebSerial AVR109) buttons
     document.getElementById('microBootModeButton')?.addEventListener('click', triggerMicroBootloader);


### PR DESCRIPTION
## Why
The combined flash page was overloaded and confusing for non-technical users — plug-in + boot mode + UF2 download + copy + finalize + a bolted-on serial panel, all on one screen with no clear order. And if you wanted serial, you were still shown UF2 download steps.

## Now
**device → model → board → "Set up your update" → one clean flow for the chosen method.**

- **Method chooser** carries the firmware version selector (shared by both flows) + two cards: **UF2 file** (recommended, default) and **Web flasher** (Beta), each with a plain-language "best for…" and OS/browser support.
- **UF2 flow**: only the UF2 steps — no version selector, no serial panel.
- **Web-flasher flow**: its own screen — plug in → enter bootloader → flash over serial → finalize. No UF2 download. The erase test tool is gated behind a `#test` hash.
- Arduino Micro keeps its dedicated serial-only flow.

Verified all three screens render and route correctly via a local preview (screenshots taken of the chooser, UF2 flow, and serial flow).

## Summary by Sourcery

Introduce a dedicated flashing-method chooser and split the adapter update experience into separate UF2 and Web flasher flows for clearer, simpler guidance.

New Features:
- Add a method chooser step that lets users pick a firmware version and choose between UF2 file and Web flasher methods, with guidance on when to use each.
- Add a dedicated Web flasher (serial) flow that walks users through plugging in, entering bootloader mode, flashing over USB, and finalizing setup, including a beta warning and OS/browser requirements.

Enhancements:
- Simplify the UF2 flashing flow by reusing the previously chosen firmware version, clarifying copy instructions, and separating it from serial flashing and version selection UI.
- Improve navigation logic so model/board selections route through the method chooser, with back buttons that behave consistently across UF2, Web flasher, and Micro-specific flows.
- Refine progress and state handling so all flashing flows share consistent step indicators and human-readable configuration/version labels.
- Gate the serial erase test tool behind a dedicated URL-hash opt-in and provide separate logging for bootloader actions in UF2 vs Web flasher flows.