### PR TITLE
Point finalize step to the Getting Started guide

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -277,7 +277,7 @@
             <ol>
                 <li>Wait 10 seconds after the firmware copies</li>
                 <li>Unplug and reconnect your Vail Adapter</li>
-                <li><strong>Important:</strong> Visit <a href="https://vailmorse.com" target="_blank">vailmorse.com</a> (the official Vail web repeater) to configure your keyer type, speed, and tone settings</li>
+                <li><strong>Important:</strong> Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up your adapter — keyer type, speed, and tone.</li>
                 <li>Your settings will be saved to the device and can be used with any compatible CW application</li>
             </ol>
             <div class="success-message">
@@ -383,7 +383,7 @@
             </div>
             <ol>
                 <li>The adapter reboots into the new firmware automatically (unplug/replug if it stays in bootloader mode)</li>
-                <li>Visit <a href="https://vailmorse.com" target="_blank">vailmorse.com</a> to configure your keyer type, speed, and tone</li>
+                <li>Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up your keyer type, speed, and tone</li>
             </ol>
             <div class="success-message">
                 <strong>✅ Done!</strong> Your Vail Adapter is running the new firmware.
@@ -465,7 +465,7 @@
             <ol>
                 <li>Wait for the bootloader to exit and the Micro to re-enumerate as your running application</li>
                 <li>Unplug and reconnect if needed</li>
-                <li>Visit <a href="https://vailmorse.com" target="_blank">vailmorse.com</a> to configure keyer type, speed, and tone via MIDI</li>
+                <li>Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up keyer type, speed, and tone</li>
             </ol>
             <div class="success-message">
                 <strong>✅ You're set!</strong> Your Arduino Micro is now running the Vail Adapter firmware.


### PR DESCRIPTION
Changes the finalize-step link in all three flows (UF2, web flasher, Arduino Micro) from vailmorse.com to the adapter's Getting Started guide at https://vailadapter.com/gettingstarted, with matching link text. URL verified (200).

## Summary by Sourcery

Enhancements:
- Align finalize-step instructions across all updater flows to link to the adapter Getting Started guide with clearer setup wording.