### PR TITLE
Add embedded time intervals to sent MIDI messages

### DIFF
--- a/adapter.cpp
+++ b/adapter.cpp
@@ -37,6 +37,8 @@ this->txRelays[1] = false; // dah
 this->lastPaddlePressed = PADDLE_DIT;
 this->ditKeyPressed = false;
 this->dahKeyPressed = false;
+this->midiEventPreviousTime = millis()-(MAX_MIDI_EVENT_DELTA+1);
+this->sendMidiEventDeltaTimes = false;
 }
 
 bool VailAdapter::KeyboardMode() {
@@ -104,6 +106,31 @@ if (down) { // Note On
     status_byte = 0x80; // MIDI Status = 0x80 (Note Off, Channel 1)
     velocity = 0x00;    // Velocity for Note Off (0x00 is common)
 }
+
+if (this->sendMidiEventDeltaTimes) {
+// The time interval since the previous key up/down event is encoded into a 14-bit
+// base 126 value. The upper 7 bits of this value are sent in a CC4 event, while
+// the lower 7 bits are sent in the note event's velocity value, avoiding 0 and 127
+// velocity values. Time values in the range [1, 16128] milliseconds can be sent.
+// If the elapsed time exceeds this, no CC event is sent and the note contains
+// its normal value of 127 (note on) or 0 (note off).
+
+    unsigned long currentTime = millis();
+    unsigned long delta = currentTime - this->midiEventPreviousTime;
+
+    this->midiEventPreviousTime = currentTime;
+    if (delta > 0 && delta <= MAX_MIDI_EVENT_DELTA) {
+        delta -= 1; // Subtract 1 to encode values in the range [1, 16128]
+	uint8_t cin = 0x0B; // CIN = 0x0B Change Control
+	uint8_t cc = 0xB0; // Change Control
+        uint8_t delta_high = delta / 126;
+	midiEventPacket_t event = {cin, cc, CN_EVENT_DELTA_HIGH, delta_high};
+	MidiUSB.sendMIDI(event);
+	// place the low 7 bits into the velocity field of the following note event
+	velocity = delta % 126 + 1; // Add 1 so the value falls in [1, 126]
+    }
+}
+
 // Construct the MIDI event packet for MIDIUSB library
 midiEventPacket_t event = {header, status_byte, key, velocity};
 MidiUSB.sendMIDI(event);
@@ -777,12 +804,12 @@ uint16_t msg = (event.byte1 << 8) | (event.byte2 << 0);
 switch (event.byte1) {
 case 0xB0:
 switch (event.byte2) {
-case 0:
+case CN_KEYBOARD_MODE:
 this->keyboardMode = (event.byte3 > 0x3f);
 Serial.print("Keyboard mode: "); Serial.println(this->keyboardMode ? "ON" : "OFF");
 MidiUSB.sendMIDI(event);
 break;
-case 1:
+case CN_DIT_DURATION:
 this->ditDuration = event.byte3 * 2 * MILLISECOND;
 if (this->keyer) {
 this->keyer->SetDitDuration(this->ditDuration);
@@ -790,11 +817,15 @@ this->keyer->SetDitDuration(this->ditDuration);
 Serial.print("Dit duration set to: "); Serial.println(this->ditDuration);
 saveSettingsToEEPROM(getCurrentKeyerType(), this->ditDuration, this->txNote);
 break;
-case 2:
+case CN_SIDETONE_NOTE:
 this->txNote = event.byte3;
 Serial.print("TX Note set to: "); Serial.println(this->txNote);
 
 saveSettingsToEEPROM(getCurrentKeyerType(), this->ditDuration, this->txNote);
+break;
+case CN_ENABLE_EVENT_DELTA:
+this->sendMidiEventDeltaTimes = (event.byte3 > 0x3f);
+Serial.print("MIDI timing: "); Serial.println(this->sendMidiEventDeltaTimes ? "ON" : "OFF");
 break;
 }
 break;

--- a/adapter.h
+++ b/adapter.h
@@ -6,6 +6,15 @@
 #include "config.h" // Include config.h
 #include "memory.h" // Include memory.h for recording state
 
+// Controller numbers
+#define CN_KEYBOARD_MODE 0
+#define CN_DIT_DURATION 1
+#define CN_SIDETONE_NOTE 2
+#define CN_ENABLE_EVENT_DELTA 3
+#define CN_EVENT_DELTA_HIGH 4
+
+#define MAX_MIDI_EVENT_DELTA 16128 // 2^7 * 126 milliseconds
+
 class VailAdapter: public Transmitter {
 private:
     unsigned int txNote = DEFAULT_TONE_NOTE;
@@ -37,6 +46,10 @@ private:
     // Track which keyboard keys are currently pressed
     bool ditKeyPressed = false;
     bool dahKeyPressed = false;
+
+    // Track last Time a MIDI event was sent
+    unsigned long midiEventPreviousTime = 0;
+    bool sendMidiEventDeltaTimes= false;
 
     // CW memory recording
     RecordingState* recordingState = nullptr;

--- a/docs/MIDI_INTEGRATION_SPEC.md
+++ b/docs/MIDI_INTEGRATION_SPEC.md
@@ -53,6 +53,28 @@ The Vail Adapter responds to the following MIDI message types:
 - **Tuning**: equal temperament
 - **Example**: `B0 02 2D` sets sidetone to note 45 = A2 (110 Hz)
 
+#### CC3 - Enable sending embedded time intervals with Key Up/Down events
+**Purpose**: Switch between sending normal MIDI notes and notes with embedded time intervals
+
+- **Message**: `B0 03 xx`
+- **Values**:
+  - `00-3F` (0-63): Disable sending embedded time intervals
+  - `40-7F` (64-127): Enable sending embedded time intervals
+- **Default**: Sending of embedded time intervals is diabled
+- **Example**: `B0 03 7F` enables sending of embedded time intervals
+
+#### CC4 - Send the upper 7 bits of the time interval between note up/down events
+**Purpose**: When sending embedded time intervals is enabled, this message is sent by
+the Vail Device just prior to sending a Note On/Off message and contains the high order
+7 bits of the time interval in milliseconds since the previous note event was sent.
+
+**Note**: This message is sent by the Vail Device to the Controlling device.
+
+- **Message**: `B0 04 xx`
+- **Values**: '00-7F' (0-127): The upper 7 bits of the 14-bit number of milliseconds elapsed since the previous key up/down event was sent.
+- **Default**: None
+- **Example**: `B0 04 00` The upper 7 bits of the time interval is 0
+
 ### Program Change Messages (0xCn)
 
 #### Keyer Mode Selection
@@ -83,8 +105,12 @@ The Vail Adapter responds to the following MIDI message types:
 
 ## MIDI Output — notes the adapter sends
 
-When in **MIDI mode**, keying produces Note On (`90 nn 7F`) / Note Off (`80 nn 00`)
-events on channel 1, where the note number `nn` is:
+### MIDI Output without embedded timing intervals
+
+When in **MIDI mode** and the sending of embedded time interval disabled
+(or if the embedded time interval cannot be expressed in 14 bits), keying produces
+Note On ('90 nn 7F') / Note Off ('80 nn 00') messages on channel 1,
+where the note number `nn` is:
 
 | Note number | Pitch | Sent for |
 |---|---|---|
@@ -96,6 +122,34 @@ In practice, set the keyer to **Passthrough (PC 0)** when you want the host to
 receive distinct dit (`1`/C#) and dah (`2`/D) events and do its own timing — this
 is how the Vail web repeater drives the adapter. With any onboard keyer (PC 1-9),
 the adapter performs the timing itself and emits note `0` (C) for each element.
+
+### MIDI Output with embedded timing intervals
+
+When in **MIDI mode** and the sending of embedded time intervals is enabled, the
+time interval since the previous Key Up/Down event is computed, irrespective
+of whether the previous event was a Key Up or a Key Down event. If that time interval
+exceeds 16128 milliseconds, keying produces Note On/Off messages as described above
+without embedded time intervals.
+
+If the time interval is less than or equal to 16128 milliseconss, the time interval
+in milliseconds is expressed in two parts, the high order 7 bits, calculated as
+
+> `high_order_bits = floor((interval - 1) / 126)`, 
+
+and the low order 7 bits, calculated as
+
+> `low_order_bits = (interval - 1) % 126 + 1`
+
+and two MIDI messages are sent for each Key Up/Down event:
+
+- the first message is 'B0 04 zz', where zz is the high order 7 bits, and
+- the second message is either '90 nn yy' for Key Down or '80 nn yy' for Key Up,
+where `nn` is the note number as described above and yy containes the low order 7 bits.
+
+The receiver of these messages can reconstruct the time interval as
+> `interval = high_order_bits * 126 + low_order_bits`,
+
+The timing interval encoding is adapted from that in the [MoMIDI Specification](https://github.com/NetKeyer/MoMIDI-Spec).
 
 ## Integration Example
 


### PR DESCRIPTION
When sending each key up/down event, also send the time in milliseconds since the previous key up/down event. The interval is encoded into a 14-bit base 126 value. The upper 7 bits of this value are sent in a CC4 event, while the lower 7 bit are sent in the note's velocity field, avoiding values of 0 and 127. Intervals of up to 16128 (128*126) milliseconds can be sent. If that time is exceeded, a time value of 0 is sent. These timing values can be used by the receiving system to recreate the morse elements with 1 mS accuracy, regardless of the jitter introduced by the communication path.

Jitter of a few milliseconds may not be significant at lower words per minute, but becomes significant at higher WPM. I find it satisfying to have end-to-end preservation of morse element and spacing lengths. They are generated in the keyer and accurately recreated at the transmitter.

This is a revision of PR#77.

## Summary by Sourcery

Add optional embedded timing intervals to MIDI key up/down events and document the new MIDI control and output behavior.

New Features:
- Introduce a configurable mode to embed inter-event timing intervals in outgoing MIDI key up/down messages using CC4 and velocity fields.
- Expose a new MIDI control change (CC3) to enable or disable sending embedded timing intervals and a CC4 payload for the high-order timing bits.

Enhancements:
- Define controller number constants and a maximum encodable MIDI event delta to centralize MIDI control configuration.
- Extend MIDI input handling to toggle timing-interval transmission and log its state changes over serial output.

Documentation:
- Expand the MIDI integration specification to describe the new CC3/CC4 controls and the encoding/decoding scheme for embedded timing intervals in MIDI output.