### PR TITLE
Updater redesign: one click flashing, board auto detect, new look

### DIFF
--- a/online-updater/esp-flasher.js
+++ b/online-updater/esp-flasher.js
@@ -362,10 +362,14 @@ class ESP32Flasher {
                 if (this.device) {
                     this.log("✓ Device reconnected!");
                     this.bootloaderModeReady = true;
-                    document.getElementById('enterBootloaderButton').style.display = 'none';
-                    document.getElementById('directConnectButton').style.display = 'none';
-                    document.getElementById('alternativeResetButton').style.display = 'none';
-                    document.getElementById('connectButton').style.display = 'inline-block';
+                    const ebBtn = document.getElementById('enterBootloaderButton');
+                    if (ebBtn) ebBtn.style.display = 'none';
+                    const dcBtn2 = document.getElementById('directConnectButton');
+                    if (dcBtn2) dcBtn2.style.display = 'none';
+                    const arBtn = document.getElementById('alternativeResetButton');
+                    if (arBtn) arBtn.style.display = 'none';
+                    const cBtn = document.getElementById('connectButton');
+                    if (cBtn) cBtn.style.display = 'inline-block';
                     return true;
                 } else {
                     this.log("Device did not reconnect as a new port.");

--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -7,8 +7,8 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=2026-07-04.3">
+    <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.5">
 </head>
 <body>
 <nav>
@@ -90,9 +90,10 @@
         </div>
     </section>
 
-    <!-- Step: Adapter model -->
-    <section id="step1_5" class="wizard-step">
-        <h2>Which model of adapter?</h2>
+    <!-- Step: Adapter model (the board inside is auto-detected over USB) -->
+    <section id="stepModel" class="wizard-step">
+        <h2>Which adapter do you have?</h2>
+        <p class="step-description">Just the model. The exact board inside gets detected automatically when you connect.</p>
 
         <div class="card-grid">
             <div class="selection-card" data-model="basic_pcb" role="button" tabindex="0">
@@ -116,35 +117,7 @@
             <div class="selection-card" data-model="non_pcb" role="button" tabindex="0">
                 <div class="card-icon">🔧</div>
                 <h3>DIY No PCB</h3>
-                <p>Hand-wired or breadboard build following GitHub specs</p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Step: Board -->
-    <section id="step2" class="wizard-step">
-        <h2>Which board is inside?</h2>
-        <p class="step-description">It's printed right on the microcontroller board.</p>
-
-        <div class="card-grid">
-            <div class="selection-card" data-board="qtpy" role="button" tabindex="0">
-                <div class="card-icon">🔷</div>
-                <h3>Adafruit QT Py</h3>
-                <p>Look for "QT Py" printed on the board</p>
-                <div class="hint" id="qtpyHint">Most purchased adapters are a QT Py, when in doubt pick this</div>
-            </div>
-
-            <div class="selection-card" data-board="xiao" role="button" tabindex="0">
-                <div class="card-icon">🔶</div>
-                <h3>Seeeduino XIAO</h3>
-                <p>Look for "XIAO" printed on the board</p>
-            </div>
-
-            <div class="selection-card" data-board="micro" id="microCard" role="button" tabindex="0">
-                <div class="card-icon">🔸</div>
-                <h3>Arduino Micro</h3>
-                <p>ATmega32U4, breadboard and DIY builds only</p>
-                <div class="hint warn">Experimental: no capacitive touch or button menu, shorter CW memories</div>
+                <p>Hand-wired or breadboard build following GitHub specs, QT Py, XIAO, or Arduino Micro</p>
             </div>
         </div>
     </section>
@@ -244,6 +217,11 @@
                 </li>
                 <li>
                     <div class="uf2-step-title">Download the firmware file</div>
+                    <div class="board-row" id="uf2BoardRow" style="display: none;">
+                        <span class="board-row-label">Board inside <span class="muted">(auto-filled if you used the button above, otherwise it's printed on the board)</span></span>
+                        <button class="board-pick" data-board="qtpy">QT Py</button>
+                        <button class="board-pick" data-board="xiao">XIAO</button>
+                    </div>
                     <a href="#" id="downloadButton" class="btn-download disabled" role="button" aria-disabled="true">
                         <span class="download-icon">⬇️</span>
                         <span id="downloadText">Download UF2 file</span>
@@ -360,6 +338,6 @@
 <script src="esp-flasher.js?v=2026-07-04.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
 <script src="samba-flasher.js?v=2026-06-13.5"></script>
-<script src="script.js?v=2026-07-04.2" defer></script>
+<script src="script.js?v=2026-07-04.4" defer></script>
 </body>
 </html>

--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -8,23 +8,13 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=2026-07-04.5">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.6">
 </head>
 <body>
 <nav>
     <div class="nav-inner">
         <a class="nav-brand" href="index.html">
-            <span class="brand-dot"></span>
-            <span class="brand-stack">
-                <span class="brand-word">VAIL UPDATER</span>
-                <svg class="brand-morse" aria-hidden="true" width="102" height="6" viewBox="0 0 102 6" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                    <!-- VAIL in morse: ...- / .- / .. / .-.. -->
-                    <circle cx="1.5" cy="3" r="1.5"/><circle cx="7.5" cy="3" r="1.5"/><circle cx="13.5" cy="3" r="1.5"/><rect x="18" y="1.5" width="9" height="3" rx="1.5"/>
-                    <circle cx="36.5" cy="3" r="1.5"/><rect x="41" y="1.5" width="9" height="3" rx="1.5"/>
-                    <circle cx="59.5" cy="3" r="1.5"/><circle cx="65.5" cy="3" r="1.5"/>
-                    <circle cx="76.5" cy="3" r="1.5"/><rect x="81" y="1.5" width="9" height="3" rx="1.5"/><circle cx="94.5" cy="3" r="1.5"/><circle cx="100.5" cy="3" r="1.5"/>
-                </svg>
-            </span>
+            <span class="brand-word">VAIL UPDATER</span>
         </a>
         <ul>
             <li><a href="troubleshoot.html">Get Help</a></li>

--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -3,69 +3,86 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vail Adapter Firmware Update</title>
+    <title>Vail Firmware Updater</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <link rel="stylesheet" href="style.css?v=2026-06-12.2">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.3">
 </head>
 <body>
 <nav>
-    <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="troubleshoot.html">Get Help</a></li>
-        <li><a href="https://vailadapter.com/assembly" target="_blank">Assembly Instructions</a></li>
-    </ul>
+    <div class="nav-inner">
+        <a class="nav-brand" href="index.html">
+            <span class="brand-dot"></span>
+            <span class="brand-stack">
+                <span class="brand-word">VAIL UPDATER</span>
+                <svg class="brand-morse" aria-hidden="true" width="102" height="6" viewBox="0 0 102 6" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <!-- VAIL in morse: ...- / .- / .. / .-.. -->
+                    <circle cx="1.5" cy="3" r="1.5"/><circle cx="7.5" cy="3" r="1.5"/><circle cx="13.5" cy="3" r="1.5"/><rect x="18" y="1.5" width="9" height="3" rx="1.5"/>
+                    <circle cx="36.5" cy="3" r="1.5"/><rect x="41" y="1.5" width="9" height="3" rx="1.5"/>
+                    <circle cx="59.5" cy="3" r="1.5"/><circle cx="65.5" cy="3" r="1.5"/>
+                    <circle cx="76.5" cy="3" r="1.5"/><rect x="81" y="1.5" width="9" height="3" rx="1.5"/><circle cx="94.5" cy="3" r="1.5"/><circle cx="100.5" cy="3" r="1.5"/>
+                </svg>
+            </span>
+        </a>
+        <ul>
+            <li><a href="troubleshoot.html">Get Help</a></li>
+            <li><a href="https://vailadapter.com/assembly" target="_blank" rel="noopener">Assembly</a></li>
+            <li><a href="https://vailadapter.com/manual" target="_blank" rel="noopener">Manual</a></li>
+        </ul>
+    </div>
 </nav>
 
 <div class="container">
-    <h1 id="pageTitle">Vail Firmware Update</h1>
+    <header class="page-header">
+        <h1 id="pageTitle">Update your Vail device</h1>
+        <p class="page-sub" id="pageSub">Pick your device and we'll take care of the rest.</p>
+    </header>
 
-    <!-- What's New Section (hidden until device selected) -->
+    <!-- Breadcrumb of choices made so far (click a chip to change it) -->
+    <div class="crumb-bar" id="crumbBar" style="display: none;"></div>
+
+    <!-- Quick resume from a previous visit -->
+    <div class="resume-card" id="resumeCard" style="display: none;">
+        <div class="resume-text">
+            <strong>Welcome back.</strong>
+            <span id="resumeSummary"></span>
+        </div>
+        <div class="resume-actions">
+            <button class="btn-primary btn-sm" id="resumeButton">Continue</button>
+            <button class="btn-ghost btn-sm" id="resumeDismiss">Start fresh</button>
+        </div>
+    </div>
+
+    <!-- What's New (shown once a device is selected) -->
     <details class="whats-new" id="whatsNewSection" style="display: none;">
         <summary>
             <span class="expand-icon">▶</span>
-            <strong><span id="whatsNewDevice">Vail</span> Updates:</strong> <span id="lastUpdateDate">Loading...</span>
-            <span class="click-hint">— Click to see what's new</span>
+            <strong><span id="whatsNewDevice">Vail</span></strong>&nbsp;<span id="lastUpdateDate">Loading...</span>
+            <span class="click-hint">what's new</span>
         </summary>
         <div id="recentCommitsScroll" class="whats-new-scroll">
             <ul id="recentCommitsList">
                 <li>Loading recent updates...</li>
             </ul>
         </div>
-        <p class="manual-link" id="releaseNotesLink" style="display: none;">📖 <a href="#" target="_blank" rel="noopener">View full release notes on GitHub →</a></p>
-        <p class="manual-link" id="manualLink">📖 <a href="https://vailadapter.com/manual" target="_blank">View User Manual</a></p>
+        <p class="manual-link" id="releaseNotesLink" style="display: none;"><a href="#" target="_blank" rel="noopener">Full release notes on GitHub →</a></p>
+        <p class="manual-link" id="manualLink"><a href="https://vailadapter.com/manual" target="_blank" rel="noopener">User manual →</a></p>
     </details>
 
-    <!-- Progress Indicator -->
-    <div class="progress-bar">
-        <div class="progress-step active" data-step="1">
-            <div class="step-number">1</div>
-            <div class="step-label">Model</div>
-        </div>
-        <div class="progress-line"></div>
-        <div class="progress-step" data-step="2">
-            <div class="step-number">2</div>
-            <div class="step-label">Board</div>
-        </div>
-        <div class="progress-line"></div>
-        <div class="progress-step" data-step="3">
-            <div class="step-number">3</div>
-            <div class="step-label">Update</div>
-        </div>
-    </div>
-
-    <!-- Step 1: Device Selection -->
+    <!-- Step: Device -->
     <section id="step1" class="wizard-step active">
-        <h2>Which Vail device do you have?</h2>
-        <p class="step-description">Choose your device type.</p>
+        <h2>Which device do you have?</h2>
 
         <div class="card-grid">
-            <div class="selection-card" data-device="adapter">
+            <div class="selection-card" data-device="adapter" role="button" tabindex="0">
                 <div class="card-icon">📡</div>
                 <h3>Vail Adapter</h3>
                 <p>USB adapter that connects paddles to your computer for web-based CW</p>
             </div>
 
-            <div class="selection-card" data-device="summit">
+            <div class="selection-card" data-device="summit" role="button" tabindex="0">
                 <div class="card-icon">⛰️</div>
                 <h3>Vail Summit</h3>
                 <p>Standalone morse code trainer with built-in screen and keyboard</p>
@@ -73,602 +90,276 @@
         </div>
     </section>
 
-    <!-- Step 1.5: Adapter Model Selection (only shown for Adapter) -->
+    <!-- Step: Adapter model -->
     <section id="step1_5" class="wizard-step">
-        <h2>What model of Vail Adapter do you have?</h2>
-        <p class="step-description">Choose the PCB version that matches your adapter.</p>
+        <h2>Which model of adapter?</h2>
 
         <div class="card-grid">
-            <div class="selection-card" data-model="basic_pcb">
+            <div class="selection-card" data-model="basic_pcb" role="button" tabindex="0">
                 <div class="card-icon">🎛️</div>
                 <h3>Basic PCB</h3>
-                <p>Standard Vail Adapter PCB with paddle inputs and sidetone</p>
+                <p>Standard PCB with paddle inputs and sidetone</p>
             </div>
 
-            <div class="selection-card" data-model="advanced_pcb">
+            <div class="selection-card" data-model="advanced_pcb" role="button" tabindex="0">
                 <div class="card-icon">⚡</div>
                 <h3>Advanced PCB</h3>
-                <p>Includes radio output port and built-in capacitive touch points</p>
+                <p>Adds a radio output port and built-in capacitive touch points</p>
             </div>
 
-            <div class="selection-card" data-model="vail_lite">
+            <div class="selection-card" data-model="vail_lite" role="button" tabindex="0">
                 <div class="card-icon">🪶</div>
                 <h3>Vail Lite</h3>
-                <p>USB stick form factor with buzzer sidetone only - no buttons, capacitive touch, headphone jack, or radio output</p>
+                <p>USB stick form factor with buzzer sidetone only</p>
             </div>
 
-            <div class="selection-card" data-model="non_pcb">
+            <div class="selection-card" data-model="non_pcb" role="button" tabindex="0">
                 <div class="card-icon">🔧</div>
                 <h3>DIY No PCB</h3>
                 <p>Hand-wired or breadboard build following GitHub specs</p>
             </div>
         </div>
-
-        <button class="btn-secondary" id="backToStep1FromModel">← Back</button>
     </section>
 
-    <!-- Step 2: Board Selection -->
+    <!-- Step: Board -->
     <section id="step2" class="wizard-step">
-        <h2>Which Arduino board are you using?</h2>
-        <p class="step-description">Select the microcontroller on your adapter.</p>
+        <h2>Which board is inside?</h2>
+        <p class="step-description">It's printed right on the microcontroller board.</p>
 
         <div class="card-grid">
-            <div class="selection-card" data-board="qtpy">
+            <div class="selection-card" data-board="qtpy" role="button" tabindex="0">
                 <div class="card-icon">🔷</div>
-                <h3>Adafruit QT Py SAMD21</h3>
-                <p>Look for "QT Py" labeling on the board</p>
-                <div class="hint" id="qtpyHint">💡 Most purchased Adapters will likely be a QT Py when in doubt</div>
+                <h3>Adafruit QT Py</h3>
+                <p>Look for "QT Py" printed on the board</p>
+                <div class="hint" id="qtpyHint">Most purchased adapters are a QT Py, when in doubt pick this</div>
             </div>
 
-            <div class="selection-card" data-board="xiao">
+            <div class="selection-card" data-board="xiao" role="button" tabindex="0">
                 <div class="card-icon">🔶</div>
-                <h3>Seeeduino XIAO SAMD21</h3>
-                <p>Look for "XIAO" labeling on the board</p>
+                <h3>Seeeduino XIAO</h3>
+                <p>Look for "XIAO" printed on the board</p>
             </div>
 
-            <div class="selection-card" data-board="micro" id="microCard">
+            <div class="selection-card" data-board="micro" id="microCard" role="button" tabindex="0">
                 <div class="card-icon">🔸</div>
                 <h3>Arduino Micro</h3>
-                <p>ATmega32U4-based. Breadboard / DIY builds only.</p>
-                <div class="hint">⚠️ Experimental: no capacitive touch, no button menu, limited CW memory length. Flashed via WebSerial (not UF2 drag-and-drop).</div>
+                <p>ATmega32U4, breadboard and DIY builds only</p>
+                <div class="hint warn">Experimental: no capacitive touch or button menu, shorter CW memories</div>
             </div>
         </div>
-
-        <button class="btn-secondary" id="backToStep1">← Back</button>
     </section>
 
-    <!-- Step 2.5: Choose firmware version + flashing method -->
-    <section id="stepMethod" class="wizard-step">
-        <h2>Set up your update</h2>
-        <p class="step-description">You've selected: <strong id="selectedConfigMethod"></strong></p>
+    <!-- Step: Update (one screen for every adapter flash path) -->
+    <section id="stepUpdate" class="wizard-step">
+        <h2>Update firmware</h2>
 
-        <!-- Pick version -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">1</span>
-                <h3>Pick a firmware version</h3>
+        <!-- Version picker -->
+        <div class="panel">
+            <div class="panel-row">
+                <label class="panel-label" for="adapterVersionSelect">Version</label>
+                <select id="adapterVersionSelect" class="version-select" disabled>
+                    <option value="">Loading releases…</option>
+                </select>
+                <label class="test-release-toggle">
+                    <input type="checkbox" id="adapterShowTestRelease">
+                    <span class="toggle-label">Test builds</span>
+                </label>
             </div>
-            <p>The latest stable release is selected by default.</p>
-            <div class="version-selector-container">
-                <div class="version-selector-row">
-                    <select id="adapterVersionSelect" class="version-select" disabled>
-                        <option value="">Loading releases…</option>
-                    </select>
-                    <label class="test-release-toggle">
-                        <input type="checkbox" id="adapterShowTestRelease">
-                        <span class="toggle-label">Show test release</span>
-                    </label>
-                </div>
-                <div id="adapterTestReleaseWarning" class="test-release-warning" style="display: none;">
-                    <strong>Warning:</strong> Test releases may not be stable and could contain bugs. They include features currently being developed. Use at your own risk.
-                </div>
-                <div id="adapterReleaseInfo" class="release-info" style="display: none;">
-                    <div class="release-info-header">
-                        <span id="adapterReleaseVersionBadge" class="firmware-version"></span>
-                        <span id="adapterReleaseDate" class="release-date"></span>
+            <div id="adapterTestReleaseWarning" class="test-release-warning" style="display: none;">
+                Test builds may be unstable. They include features still in development.
+            </div>
+            <details class="release-notes-details" id="adapterReleaseDetails" style="display: none;">
+                <summary>Release notes <span id="adapterReleaseDate" class="release-date"></span></summary>
+                <div id="adapterReleaseNotes" class="release-notes"></div>
+            </details>
+        </div>
+
+        <!-- Method toggle -->
+        <div class="method-toggle" id="methodToggle" role="tablist">
+            <button class="method-tab active" id="tabSerial" data-method="serial" role="tab">⚡ Install from browser</button>
+            <button class="method-tab" id="tabUf2" data-method="uf2" role="tab">📁 Download file</button>
+        </div>
+
+        <!-- Browser flash panel -->
+        <div class="method-panel active" id="methodSerialPanel">
+            <div class="no-webserial" id="noWebSerialNote" style="display: none;">
+                This browser can't talk to USB devices. Use <strong>Chrome, Edge, or Opera</strong> on a computer, or switch to the <button class="linklike" id="switchToUf2">Download file</button> method.
+            </div>
+
+            <div class="flash-hero" id="flashHero">
+                <p class="flash-hero-text" id="flashHeroText">Plug in your adapter, then click the button. Your browser will ask which device to use the first time.</p>
+                <button id="flashNowButton" class="btn-hero">Update firmware</button>
+                <div class="flash-hint" id="flashHint" style="display: none;"></div>
+
+                <ol class="flash-timeline" id="flashTimeline" style="display: none;">
+                    <li data-stage="find"><span class="tl-dot"></span>Find your adapter</li>
+                    <li data-stage="boot"><span class="tl-dot"></span>Enter bootloader</li>
+                    <li data-stage="write"><span class="tl-dot"></span>Install firmware
+                        <div class="progress-track" id="serialProgressTrack" style="display: none;">
+                            <div class="progress-fill" id="serialFlashProgressBar"></div>
+                        </div>
+                    </li>
+                    <li data-stage="done"><span class="tl-dot"></span>Done</li>
+                </ol>
+
+                <div class="flash-result" id="flashResult" style="display: none;"></div>
+            </div>
+
+            <details class="advanced" id="flashAdvanced">
+                <summary>Advanced options &amp; troubleshooting</summary>
+                <div class="advanced-body">
+                    <p class="advanced-note">The update button above handles all of this automatically. These are here for when something goes sideways.</p>
+                    <div class="advanced-actions">
+                        <button id="bootOnlyButton" class="btn-secondary btn-sm">Enter bootloader mode only</button>
+                        <button id="manualPortButton" class="btn-secondary btn-sm">Pick port manually &amp; install</button>
+                        <button id="forgetPortsButton" class="btn-secondary btn-sm">Forget remembered devices</button>
                     </div>
-                    <div id="adapterReleaseNotes" class="release-notes"></div>
-                </div>
-            </div>
-        </div>
+                    <ul class="advanced-tips">
+                        <li>You can also enter bootloader mode by double-tapping the reset button on the adapter. A drive named QTPYBOOT, XIAOBOOT, or ADAPTERBOOT will appear.</li>
+                        <li>The normal picker is filtered to devices that look like your adapter. "Pick port manually" shows every serial port on the system.</li>
+                        <li>Linux permission denied: <code>sudo usermod -a -G dialout $USER</code> then log out and back in.</li>
+                    </ul>
 
-        <!-- Pick method -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">2</span>
-                <h3>Choose how to flash</h3>
-            </div>
-            <p>Two ways to get the firmware onto your adapter. <strong>Not sure? Use the UF2 file method</strong> — it's the simplest and works almost everywhere.</p>
-
-            <div class="card-grid">
-                <div class="selection-card" data-method="uf2">
-                    <div class="card-icon">📄</div>
-                    <h3>UF2 file <span style="font-size: 12px; color: #4CAF50; font-weight: 600;">★ Recommended</span></h3>
-                    <p>Download a small file and drag it onto a drive that pops up. No special browser needed for the copy.</p>
-                    <div class="hint">✅ Works on Windows, macOS, Linux, ChromeOS — and even a phone. Best for most people.</div>
-                </div>
-
-                <div class="selection-card" data-method="serial">
-                    <div class="card-icon">🔌</div>
-                    <h3>Web flasher <span style="font-size: 12px; color: #b388ff; font-weight: 600;">BETA</span></h3>
-                    <p>Flashes straight over the USB port from your browser — nothing to download or drag.</p>
-                    <div class="hint">💡 Try this if the UF2 copy stalls or you'd rather not handle files. Requires <strong>Chrome, Edge, or Opera on a computer</strong> (not Safari, Firefox, or phones).</div>
-                </div>
-            </div>
-        </div>
-
-        <button class="btn-secondary" id="backToBoardFromMethod">← Back</button>
-    </section>
-
-    <!-- Step 3: Flash Adapter Firmware (UF2) -->
-    <section id="step3" class="wizard-step">
-        <h2>Flash Your Firmware</h2>
-        <p class="step-description">You've selected: <strong id="selectedConfig"></strong></p>
-
-        <!-- Sub-step 1: Plug In -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">1</span>
-                <h3>Plug In Your Adapter</h3>
-            </div>
-            <p>Use a USB-C cable (must support data transfer) and connect your Vail Adapter to your computer.</p>
-        </div>
-
-        <!-- Sub-step 2: Enter Boot Mode -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">2</span>
-                <h3>Enter Boot Mode</h3>
-            </div>
-            <p>Choose one of these methods to put your adapter into bootloader mode:</p>
-
-            <div class="boot-methods">
-                <div class="boot-method">
-                    <h4>Method 1: WebSerial (Recommended)</h4>
-                    <p>Click the button below to automatically trigger boot mode. Works in Chrome, Edge, and Opera browsers.</p>
-                    <button id="bootModeButton" class="btn-primary">🔌 Enter Boot Mode via WebSerial</button>
-                    <div class="log-container">
-                        <h4>Activity Log:</h4>
-                        <pre id="serialLog"></pre>
+                    <div id="serialEraseTest" style="display: none;">
+                        <p class="advanced-note"><strong>Testing tool:</strong> erase the firmware to reproduce the "stuck in bootloader" state (recoverable, the bootloader is never touched).</p>
+                        <button id="serialEraseButton" class="btn-secondary btn-sm danger">🧪 Erase app (simulate stuck state)</button>
                     </div>
+
+                    <details class="log-details">
+                        <summary>Activity log</summary>
+                        <pre id="serialFlashLog" class="log-pre"></pre>
+                    </details>
                 </div>
+            </details>
+        </div>
 
-                <div class="boot-method">
-                    <h4>Method 2: Manual Reset (Double-tap)</h4>
-                    <p>Quickly double-tap the reset button on your adapter. The board should appear as a USB storage device (e.g., "QTPYBOOT" or "XIAOBOOT").</p>
+        <!-- UF2 file panel -->
+        <div class="method-panel" id="methodUf2Panel">
+            <ol class="uf2-steps">
+                <li>
+                    <div class="uf2-step-title">Put the adapter in bootloader mode</div>
+                    <p>Click below and pick your adapter, or double-tap the reset button on the board. Either way a USB drive named <strong>QTPYBOOT</strong>, <strong>XIAOBOOT</strong>, or <strong>ADAPTERBOOT</strong> appears.</p>
+                    <button id="bootModeButton" class="btn-secondary">Enter bootloader mode</button>
+                    <div class="flash-hint" id="uf2BootHint" style="display: none;"></div>
+                </li>
+                <li>
+                    <div class="uf2-step-title">Download the firmware file</div>
+                    <a href="#" id="downloadButton" class="btn-download disabled" role="button" aria-disabled="true">
+                        <span class="download-icon">⬇️</span>
+                        <span id="downloadText">Download UF2 file</span>
+                    </a>
+                </li>
+                <li>
+                    <div class="uf2-step-title">Drag the file onto the boot drive</div>
+                    <p>Drop the downloaded .uf2 onto the QTPYBOOT / XIAOBOOT / ADAPTERBOOT drive. The drive ejects itself when the update finishes, then the adapter restarts on the new firmware.</p>
+                </li>
+            </ol>
+
+            <div class="success-message subtle">
+                All done? Head to the <a href="https://vailadapter.com/gettingstarted" target="_blank" rel="noopener">Getting Started guide</a> to set your keyer type, speed, and tone.
+            </div>
+
+            <details class="advanced">
+                <summary>Troubleshooting</summary>
+                <div class="advanced-body">
+                    <ul class="advanced-tips">
+                        <li>No boot drive appears: try a different USB cable (many are charge-only), a different USB port, or slow down the double-tap.</li>
+                        <li>The copy hangs on Windows: switch to the <strong>Install from browser</strong> method, it writes over the COM port instead.</li>
+                        <li>Bootloader button needs Chrome, Edge, or Opera. On other browsers use the double-tap method.</li>
+                        <li>Linux permission denied: <code>sudo usermod -a -G dialout $USER</code> then log out and back in.</li>
+                    </ul>
+                    <details class="log-details">
+                        <summary>Activity log</summary>
+                        <pre id="serialLog" class="log-pre"></pre>
+                    </details>
                 </div>
-            </div>
-        </div>
-
-        <!-- Sub-step 3: Download Firmware -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">3</span>
-                <h3>Download the Firmware File</h3>
-            </div>
-            <p>This is the firmware version you picked on the previous screen — <strong id="uf2VersionLabel">the selected release</strong>.</p>
-            <a href="#" id="downloadButton" class="btn-download disabled" role="button" aria-disabled="true">
-                <span class="download-icon">⬇️</span>
-                <span id="downloadText">Download UF2 File</span>
-            </a>
-        </div>
-
-        <!-- Sub-step 4: Copy to Device -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">4</span>
-                <h3>Copy Firmware to Device</h3>
-            </div>
-            <ol>
-                <li>Open your file explorer (Finder on Mac, File Explorer on Windows)</li>
-                <li>Find your Downloads folder and locate the downloaded .uf2 file</li>
-                <li>Look for the adapter drive (named "QTPYBOOT", "XIAOBOOT", "ADAPTERBOOT", or similar)</li>
-                <li>Drag and drop the .uf2 file onto the adapter drive</li>
-                <li>Wait for the LED to stop flashing - the drive will automatically disconnect when complete</li>
-            </ol>
-        </div>
-
-        <!-- Sub-step 5: Finalize -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">5</span>
-                <h3>Finalize Setup</h3>
-            </div>
-            <ol>
-                <li>Wait 10 seconds after the firmware copies</li>
-                <li>Unplug and reconnect your Vail Adapter</li>
-                <li><strong>Important:</strong> Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up your adapter — keyer type, speed, and tone.</li>
-                <li>Your settings will be saved to the device and can be used with any compatible CW application</li>
-            </ol>
-            <div class="success-message">
-                <strong>✅ You're all set!</strong> Your Vail Adapter is now running the latest firmware.
-            </div>
-        </div>
-
-        <!-- Troubleshooting -->
-        <div class="troubleshooting">
-            <h3>❓ Troubleshooting</h3>
-            <details>
-                <summary>Device doesn't appear as storage drive</summary>
-                <p>Try these steps:</p>
-                <ul>
-                    <li>Try the double-tap reset method instead of WebSerial</li>
-                    <li>Use a different USB-C cable (some cables are charge-only)</li>
-                    <li>Try a different USB port on your computer</li>
-                    <li>Wait 5 seconds between taps when double-tapping the reset button</li>
-                </ul>
-            </details>
-
-            <details>
-                <summary>WebSerial button doesn't work</summary>
-                <p>WebSerial requires Chrome, Edge, or Opera browser. If you're using Firefox or Safari, please switch browsers or use the manual reset method.</p>
-            </details>
-
-            <details>
-                <summary>Linux: Permission denied</summary>
-                <p>Add your user to the dialout group: <code>sudo usermod -a -G dialout $USER</code> then log out and back in.</p>
             </details>
         </div>
-
-        <button class="btn-secondary" id="backToMethodFromUf2">← Back</button>
-        <button class="btn-primary" id="startOver">Start Over</button>
     </section>
 
-    <!-- Step 3 (Serial / Web flasher variant): SAM-BA over WebSerial -->
-    <section id="stepSerial" class="wizard-step">
-        <h2>Flash Over USB (Web Flasher)</h2>
-        <p class="step-description">You've selected: <strong id="selectedConfigSerial"></strong></p>
-
-        <div class="warning-box" style="background: linear-gradient(135deg, #2a2350 0%, #3a3066 100%); border: 2px solid #b388ff; border-radius: 8px; padding: 14px; margin-bottom: 20px;">
-            <strong style="color: #d0b3ff;">Beta feature.</strong> Requires <strong>Chrome, Edge, or Opera on a computer</strong> (not Safari, Firefox, or phones). Flashes directly over the USB port — no file to download or drag. If it doesn't work, go back and use the UF2 file method.
-        </div>
-
-        <!-- Sub-step 1: Plug in -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">1</span>
-                <h3>Plug In Your Adapter</h3>
-            </div>
-            <p>Connect the adapter with a USB cable that supports data transfer.</p>
-        </div>
-
-        <!-- Sub-step 2: Enter bootloader -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">2</span>
-                <h3>Enter Bootloader Mode</h3>
-            </div>
-            <p><strong>Double-tap the reset button</strong> on your adapter — a USB drive named "QTPYBOOT", "XIAOBOOT", or "ADAPTERBOOT" should appear. (If your adapter is already stuck in this mode, you're ready.)</p>
-            <p style="margin-top: 10px;">Or click below to trigger it automatically:</p>
-            <button id="serialBootButton" class="btn-primary">🔌 Enter Bootloader via WebSerial</button>
-            <div class="log-container" style="margin-top: 12px;">
-                <h4>Activity Log:</h4>
-                <pre id="serialBootLog"></pre>
-            </div>
-        </div>
-
-        <!-- Sub-step 3: Flash -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">3</span>
-                <h3>Flash the Firmware</h3>
-            </div>
-            <p>Click below and pick your adapter's <strong>COM port</strong> (on Windows it's usually the highest-numbered COM port that appears when the bootloader is active). The firmware writes directly over the connection.</p>
-            <button id="serialFlashButton" class="btn-primary">⚡ Flash Firmware Over Serial</button>
-
-            <div class="progress-container" id="serialFlashProgressContainer" style="display: none; margin-top: 16px;">
-                <div class="progress-label" id="serialFlashProgressLabel">Preparing…</div>
-                <div style="background: #2a2a2a; border-radius: 8px; overflow: hidden; height: 20px;">
-                    <div id="serialFlashProgressBar" style="background: linear-gradient(90deg, #6a5acd, #836fff); height: 100%; width: 0%; transition: width 0.2s;"></div>
-                </div>
-                <div id="serialFlashProgressPercent" style="margin-top: 6px; font-size: 13px; color: #999;">0%</div>
-            </div>
-            <div class="log-container" style="margin-top: 16px;">
-                <h4>Flash Log:</h4>
-                <pre id="serialFlashLog"></pre>
-            </div>
-
-            <!-- Test-only: revealed when the URL hash contains "test" -->
-            <div id="serialEraseTest" style="display: none; margin-top: 14px; padding-top: 12px; border-top: 1px solid #444;">
-                <p style="font-size: 13px; color: #b0a0e0; margin: 0 0 8px;"><strong>Testing tool:</strong> erase the firmware to reproduce the "stuck in bootloader" state (recoverable — the bootloader is never touched).</p>
-                <button id="serialEraseButton" class="btn-secondary" style="border-color: #b5651d; color: #ffb27a;">🧪 Erase app (simulate stuck state)</button>
-            </div>
-        </div>
-
-        <!-- Sub-step 4: Finalize -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">4</span>
-                <h3>Finalize Setup</h3>
-            </div>
-            <ol>
-                <li>The adapter reboots into the new firmware automatically (unplug/replug if it stays in bootloader mode)</li>
-                <li>Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up your keyer type, speed, and tone</li>
-            </ol>
-            <div class="success-message">
-                <strong>✅ Done!</strong> Your Vail Adapter is running the new firmware.
-            </div>
-        </div>
-
-        <button class="btn-secondary" id="backToMethodFromSerial">← Back</button>
-        <button class="btn-primary" id="startOverFromSerial">Start Over</button>
-    </section>
-
-    <!-- Step 3 (Micro variant): WebSerial AVR109 flash flow -->
-    <section id="step3_micro" class="wizard-step">
-        <h2>Flash Your Arduino Micro</h2>
-        <p class="step-description">You've selected: <strong id="selectedConfigMicro"></strong></p>
-
-        <div class="warning-box" style="background: linear-gradient(135deg, #3a2a00 0%, #4a3600 100%); border: 2px solid #ffc107; border-radius: 8px; padding: 16px; margin-bottom: 20px;">
-            <h3 style="margin-top: 0; color: #ffc107;">⚠️ Experimental board</h3>
-            <ul style="margin: 8px 0 0 18px; color: #e0e0e0;">
-                <li>No capacitive touch, no button menu, no LED status indicators</li>
-                <li>CW memory slots reduced to 3 × ~12 seconds (vs. 25 seconds on SAMD21)</li>
-                <li>Requires Chrome, Edge, or Opera — the flasher uses WebSerial</li>
-                <li>Radio output on A2/A3 is 5V logic — check radio tolerance before wiring</li>
-            </ul>
-        </div>
-
-        <!-- Sub-step 1: Plug In -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">1</span>
-                <h3>Plug In Your Arduino Micro</h3>
-            </div>
-            <p>Connect the Micro to your computer using a micro-USB data cable. Wait a few seconds for your OS to recognize it as a serial device.</p>
-        </div>
-
-        <!-- Sub-step 2: Enter Bootloader -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">2</span>
-                <h3>Enter Bootloader Mode</h3>
-            </div>
-            <p>Click the button below, then select your Arduino Micro in the browser's serial port picker. The browser will briefly open the port at 1200 baud and close it — this signals the Caterina bootloader to take over for ~8 seconds.</p>
-            <button id="microBootModeButton" class="btn-primary">🔌 Trigger Bootloader (1200-baud Touch)</button>
-            <div class="log-container" style="margin-top: 12px;">
-                <h4>Activity Log:</h4>
-                <pre id="microSerialLog"></pre>
-            </div>
-            <div style="margin-top: 10px; font-size: 14px; color: #ccc;">
-                <strong>Alternative:</strong> press the reset button on the Micro twice quickly to force bootloader mode manually.
-            </div>
-        </div>
-
-        <!-- Sub-step 3: Flash -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">3</span>
-                <h3>Flash Firmware</h3>
-            </div>
-            <p>Once the Micro is in bootloader mode (a new serial port will appear for ~8 seconds), click the button below and select that <strong>new</strong> bootloader port. The firmware will be written directly over the serial connection.</p>
-            <button id="microFlashButton" class="btn-primary">⚡ Flash Firmware via WebSerial</button>
-            <div class="progress-container" id="microProgressContainer" style="display: none; margin-top: 16px;">
-                <div class="progress-label" id="microProgressLabel">Preparing…</div>
-                <div style="background: #2a2a2a; border-radius: 8px; overflow: hidden; height: 20px;">
-                    <div id="microProgressBar" style="background: linear-gradient(90deg, #4CAF50, #45a049); height: 100%; width: 0%; transition: width 0.2s;"></div>
-                </div>
-                <div id="microProgressPercent" style="margin-top: 6px; font-size: 13px; color: #999;">0%</div>
-            </div>
-            <div class="log-container" style="margin-top: 16px;">
-                <h4>Flash Log:</h4>
-                <pre id="microFlashLog"></pre>
-            </div>
-        </div>
-
-        <!-- Sub-step 4: Finalize -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">4</span>
-                <h3>Finalize Setup</h3>
-            </div>
-            <ol>
-                <li>Wait for the bootloader to exit and the Micro to re-enumerate as your running application</li>
-                <li>Unplug and reconnect if needed</li>
-                <li>Visit the <a href="https://vailadapter.com/gettingstarted" target="_blank">Getting Started guide</a> to set up keyer type, speed, and tone</li>
-            </ol>
-            <div class="success-message">
-                <strong>✅ You're set!</strong> Your Arduino Micro is now running the Vail Adapter firmware.
-            </div>
-        </div>
-
-        <!-- Troubleshooting -->
-        <div class="troubleshooting">
-            <h3>❓ Troubleshooting</h3>
-            <details>
-                <summary>No new port appears after the 1200-baud touch</summary>
-                <p>The Caterina bootloader only stays active for ~8 seconds. If you miss the window, just click "Trigger Bootloader" again — or double-tap the reset button on the Micro.</p>
-            </details>
-            <details>
-                <summary>"Expected 0x0D" or timeout errors</summary>
-                <p>You likely selected the running-app port instead of the new bootloader port. Re-trigger the bootloader and pick the newer COM/ttyACM number.</p>
-            </details>
-            <details>
-                <summary>WebSerial not supported</summary>
-                <p>Use Chrome, Edge, or Opera. Firefox and Safari do not support the Web Serial API.</p>
-            </details>
-            <details>
-                <summary>Linux: Permission denied</summary>
-                <p>Add your user to the dialout group: <code>sudo usermod -a -G dialout $USER</code> then log out and back in.</p>
-            </details>
-        </div>
-
-        <button class="btn-secondary" id="backToStep2FromMicro">← Back</button>
-        <button class="btn-primary" id="startOverFromMicro">Start Over</button>
-    </section>
-
-    <!-- Step 4: Flash Summit Firmware (ESP32 Web Flasher) -->
+    <!-- Step: Summit (ESP32 web flasher) -->
     <section id="step4" class="wizard-step">
-        <h2>Flash Vail Summit Firmware</h2>
-        <p class="step-description">Web-based ESP32 flasher for the Vail Summit</p>
+        <h2>Update your Summit</h2>
 
-        <!-- Version Selection -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">1</span>
-                <h3>Select Firmware Version</h3>
+        <!-- Version picker -->
+        <div class="panel">
+            <div class="panel-row">
+                <label class="panel-label" for="versionSelect">Version</label>
+                <select id="versionSelect" class="version-select" disabled>
+                    <option value="">Loading releases...</option>
+                </select>
+                <label class="test-release-toggle">
+                    <input type="checkbox" id="showTestRelease">
+                    <span class="toggle-label">Test builds</span>
+                </label>
             </div>
-            <p>Choose which firmware version to flash. The latest stable release is selected by default.</p>
+            <div id="testReleaseWarning" class="test-release-warning" style="display: none;">
+                Test builds may be unstable. They include features still in development.
+            </div>
+            <details class="release-notes-details" id="releaseInfo" style="display: none;">
+                <summary>Release notes <span id="releaseDateDisplay" class="release-date"></span></summary>
+                <span id="releaseVersionBadge" class="firmware-version" style="display: none;"></span>
+                <div id="releaseNotes" class="release-notes"></div>
+            </details>
+        </div>
 
-            <div class="version-selector-container">
-                <div class="version-selector-row">
-                    <select id="versionSelect" class="version-select" disabled>
-                        <option value="">Loading releases...</option>
-                    </select>
-                    <label class="test-release-toggle">
-                        <input type="checkbox" id="showTestRelease">
-                        <span class="toggle-label">Show test release</span>
-                    </label>
+        <div id="espFlasherContainer">
+            <div class="flash-hero">
+                <p class="flash-hero-text">Plug in your Summit with a USB-C data cable, then connect. The flasher puts it in bootloader mode automatically and shows the install options.</p>
+                <div class="esp-buttons">
+                    <button id="enterBootloaderButton" class="btn-hero">Connect to Summit</button>
+                    <button id="connectButton" class="btn-primary" style="display: none;">Connect and Flash</button>
+                    <button id="programButton" class="btn-download" style="display: none;">Flash Firmware</button>
+                    <button id="eraseAndFlashButton" class="btn-warning" style="display: none;">Full Erase &amp; Flash (fixes USB issues)</button>
+                    <button id="eraseButton" class="btn-secondary" style="display: none;">Erase Only</button>
+                    <button id="disconnectButton" class="btn-secondary" style="display: none;">Disconnect</button>
                 </div>
 
-                <div id="testReleaseWarning" class="test-release-warning" style="display: none;">
-                    <strong>Warning:</strong> Test releases may not be stable and could contain bugs. They include features currently being developed. Use at your own risk.
-                </div>
-
-                <div id="releaseInfo" class="release-info" style="display: none;">
-                    <div class="release-info-header">
-                        <span id="releaseVersionBadge" class="firmware-version"></span>
-                        <span id="releaseDateDisplay" class="release-date"></span>
+                <div class="progress-container" id="progressContainer" style="display: none;">
+                    <div class="progress-label" id="progressLabel">Preparing...</div>
+                    <div class="progress-track">
+                        <div class="progress-fill" id="progressBar"></div>
                     </div>
-                    <div id="releaseNotes" class="release-notes"></div>
+                    <div class="progress-percent" id="progressPercent">0%</div>
                 </div>
             </div>
-        </div>
 
-        <!-- Flash Instructions -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">2</span>
-                <h3>Connect Your Device</h3>
-            </div>
-            <p>Make sure your Vail Summit is plugged in via USB-C.</p>
-        </div>
-
-        <!-- ESP32 Flash Interface -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">3</span>
-                <h3>Flash Firmware</h3>
-            </div>
-
-            <div id="espFlasherContainer">
-                <!-- Primary Method: Automatic Connection -->
-                <div class="auto-flash-section">
-                    <p style="margin-bottom: 1rem;">Click the button below to connect to your Summit. The flasher will automatically enter bootloader mode and show flash options.</p>
-                    <button id="enterBootloaderButton" class="btn-primary highlight-button">🔌 Connect to Summit</button>
-                </div>
-
-                <!-- Fallback: Manual Bootloader Entry -->
-                <details class="manual-fallback" style="margin-top: 1.5rem;">
-                    <summary style="cursor: pointer; color: #ffc107; font-weight: 500;">⚠️ Connection not working? Try manual bootloader entry</summary>
-                    <div class="manual-bootloader-instructions" style="padding: 1rem; margin-top: 0.5rem; background: rgba(255, 193, 7, 0.1); border-radius: 8px; border: 1px solid rgba(255, 193, 7, 0.3);">
-                        <p style="margin: 0 0 1rem; color: #ccc;">If automatic connection fails (e.g., "port in use" error), manually enter bootloader mode:</p>
-                        <ol style="margin: 0 0 1rem; padding-left: 1.5rem;">
+            <details class="advanced">
+                <summary>Advanced options &amp; troubleshooting</summary>
+                <div class="advanced-body">
+                    <div class="manual-bootloader-instructions">
+                        <p class="advanced-note">If automatic connection fails (like a "port in use" error), enter bootloader mode by hand:</p>
+                        <ol>
                             <li>Hold down the <strong>BOOT</strong> button on your Summit</li>
                             <li>While holding BOOT, press and release <strong>RESET</strong></li>
                             <li>Release the <strong>BOOT</strong> button</li>
-                            <li>Your device will now show as "USB JTAG/Serial" instead of "TinyUSB CDC"</li>
+                            <li>The device now shows up as "USB JTAG/Serial" instead of "TinyUSB CDC"</li>
                         </ol>
-                        <button id="directConnectButton" class="btn-warning">I'm in Bootloader Mode - Connect</button>
+                        <button id="directConnectButton" class="btn-warning btn-sm">I'm in bootloader mode, connect</button>
                     </div>
-                </details>
-                <button id="connectButton" class="btn-primary" style="display: none;">Connect and Flash</button>
-                <button id="disconnectButton" class="btn-secondary" style="display: none;">Disconnect</button>
-                <button id="programButton" class="btn-download" style="display: none;">Flash Firmware</button>
-                <button id="eraseAndFlashButton" class="btn-warning" style="display: none;">Full Erase & Flash (Recommended for USB issues)</button>
-                <button id="eraseButton" class="btn-secondary" style="display: none;">Erase Only</button>
-
-                <div class="progress-container" id="progressContainer" style="display: none; margin-top: 20px;">
-                    <div class="progress-label" id="progressLabel">Preparing...</div>
-                    <div style="background: #e0e0e0; border-radius: 8px; overflow: hidden; height: 24px;">
-                        <div id="progressBar" style="background: linear-gradient(90deg, #4CAF50, #45a049); height: 100%; width: 0%; transition: width 0.3s;"></div>
-                    </div>
-                    <div id="progressPercent" style="margin-top: 8px; font-size: 14px; color: #666;">0%</div>
+                    <ul class="advanced-tips">
+                        <li>"Port in use" on Windows: close Arduino IDE, PuTTY, or any serial monitor, then try again. Still stuck? Device Manager → Ports → right-click the COM port → Disable, wait 2 seconds, Enable.</li>
+                        <li>Flashing fails or stalls: unplug for 5 seconds, replug, and use the manual BOOT + RESET steps above.</li>
+                        <li>Some cables are charge-only. Use one you know carries data.</li>
+                        <li>Web Serial needs Chrome, Edge, or Opera on a computer.</li>
+                    </ul>
+                    <details class="log-details">
+                        <summary>Flash log</summary>
+                        <pre id="espFlashLog" class="log-pre"></pre>
+                    </details>
                 </div>
+            </details>
 
-                <div class="log-container" style="margin-top: 20px;">
-                    <h4>Flash Log:</h4>
-                    <pre id="espFlashLog"></pre>
-                </div>
+            <div class="success-message subtle">
+                When flashing finishes the Summit restarts on its own. If it doesn't, unplug it, wait 2 seconds, and plug it back in. Then follow the on-screen setup wizard.
             </div>
         </div>
-
-        <!-- Finalize -->
-        <div class="flash-step">
-            <div class="step-header">
-                <span class="step-badge">4</span>
-                <h3>Complete!</h3>
-            </div>
-            <p>Once flashing is complete, your device will automatically restart with the new firmware. If it doesn't restart automatically:</p>
-            <ol>
-                <li><strong>Unplug</strong> your Vail Summit from USB</li>
-                <li><strong>Wait 2 seconds</strong></li>
-                <li><strong>Plug it back in</strong> to power it on</li>
-                <li>Follow the on-screen setup wizard to configure WiFi and preferences</li>
-            </ol>
-            <div class="success-message">
-                <strong>✅ You're all set!</strong> Your Vail Summit is ready for morse code training.
-            </div>
-        </div>
-
-        <!-- Troubleshooting -->
-        <div class="troubleshooting">
-            <h3>❓ Troubleshooting</h3>
-            <details>
-                <summary>Browser doesn't support Web Serial</summary>
-                <p>Web Serial API is required for ESP32 flashing. Please use Chrome, Edge, or Opera browser. Firefox and Safari are not currently supported.</p>
-            </details>
-
-            <details>
-                <summary>"Port in use" or "Cannot access COM port" error</summary>
-                <p>This is common on Windows. Try these solutions:</p>
-                <ol>
-                    <li><strong>Use manual bootloader entry:</strong> Expand the yellow section above and follow the BOOT + RESET instructions.</li>
-                    <li><strong>Close other programs:</strong> Make sure Arduino IDE, PuTTY, or any other serial terminal is completely closed.</li>
-                    <li><strong>Windows Device Manager fix:</strong>
-                        <ul>
-                            <li>Open Device Manager (Win+X → Device Manager)</li>
-                            <li>Find the COM port under "Ports (COM & LPT)"</li>
-                            <li>Right-click → Disable device, wait 2 seconds</li>
-                            <li>Right-click → Enable device</li>
-                            <li>Try flashing again</li>
-                        </ul>
-                    </li>
-                    <li><strong>Try a different USB port</strong> - preferably a USB 2.0 port if available.</li>
-                </ol>
-            </details>
-
-            <details>
-                <summary>Device shows as "TinyUSB CDC" but won't connect</summary>
-                <p>Some devices use TinyUSB which doesn't support automatic bootloader entry. Use manual bootloader entry:</p>
-                <ol>
-                    <li>Hold down the <strong>BOOT</strong> button</li>
-                    <li>While holding BOOT, press and release <strong>RESET</strong></li>
-                    <li>Release the BOOT button</li>
-                    <li>Device will now show as "USB JTAG/Serial"</li>
-                    <li>Click "I'm in Bootloader Mode - Connect Now"</li>
-                </ol>
-            </details>
-
-            <details>
-                <summary>Flashing failed or stuck</summary>
-                <p>If flashing fails:</p>
-                <ul>
-                    <li>Unplug the device, wait 5 seconds, and reconnect</li>
-                    <li>Try manual bootloader entry (BOOT + RESET)</li>
-                    <li>Try a different USB cable (some cables are charge-only)</li>
-                </ul>
-            </details>
-        </div>
-
-        <button class="btn-secondary" id="backToStep1FromSummit">← Back</button>
-        <button class="btn-primary" id="startOverFromSummit">Start Over</button>
     </section>
 </div>
 
-<script src="esp-flasher.js?v=2026-06-11.1" type="module"></script>
+<script src="esp-flasher.js?v=2026-07-04.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
 <script src="samba-flasher.js?v=2026-06-13.5"></script>
-<script src="script.js?v=2026-06-13.6" defer></script>
+<script src="script.js?v=2026-07-04.2" defer></script>
 </body>
 </html>

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -1,36 +1,47 @@
-// Wizard state management
+// Vail firmware updater — wizard flow + one-click WebSerial flashing.
+//
+// Port handling philosophy: the user should pick their adapter at most ONCE.
+// Web Serial permissions persist per USB device (vendor/product/serial), so
+// every port we've ever been granted comes back via navigator.serial.getPorts().
+// The app firmware and the bootloader enumerate as different USB devices
+// (Adafruit/Seeed/Arduino convention: app PID has the 0x8000 bit set, the
+// bootloader PID is the same value without it), so we classify granted ports
+// by their USB IDs and only fall back to the browser picker when we've never
+// seen the device before.
+
+// Wizard state
 const wizardState = {
-    currentStep: 1,
-    device: null,     // 'adapter' or 'summit'
-    model: null,      // 'basic_pcb', 'advanced_pcb', or 'non_pcb' (for adapter only)
-    board: null,      // 'qtpy' or 'xiao' (for adapter only)
+    step: 'device',
+    device: null,     // 'adapter' | 'summit'
+    model: null,      // 'basic_pcb' | 'advanced_pcb' | 'vail_lite' | 'non_pcb'
+    board: null,      // 'qtpy' | 'xiao' | 'micro' | 'trinkey'
+    flashMethod: 'serial', // 'serial' | 'uf2'
 };
 
-// CORS proxy for cross-origin firmware fetches (Arduino Micro WebSerial flow).
-// The same Cloudflare Worker that serves Summit; generalized to accept a repo
-// segment: /<repo>/<tag>/<file>. See tools/firmware-proxy/worker.js.
+const STORAGE_KEY = 'vailUpdaterSetup';
+
+// CORS proxy for cross-origin firmware fetches. The same Cloudflare Worker that
+// serves Summit; generalized to accept a repo segment: /<repo>/<tag>/<file>.
 const ADAPTER_FIRMWARE_PROXY = 'https://vail-firmware-proxy.brett-hollifield.workers.dev';
 
-// --- Adapter release/version selector ------------------------------------
-// Mirrors the Summit ESP flasher: a version dropdown + "Show test release"
-// checkbox driven by GitHub Releases. Pre-releases are surfaced as the test
-// option. Per-version firmware comes from the release's attached assets,
-// which the build workflow stamps with the tag (e.g. xiao_basic_pcb_v2_v5.0.uf2).
 // Only surface releases at or above this version. Earlier releases used a
 // different firmware layout/board set and shouldn't be offered for flashing.
 const MIN_ADAPTER_VERSION = 5.0;
 
+const webSerialSupported = ('serial' in navigator);
+
+// --- Adapter release/version selector ---------------------------------------
+
 const adapterReleases = {
-    stable: [],          // published, non-prerelease releases that carry firmware assets
-    testRelease: null,   // most recent pre-release with firmware assets (the "test" build)
-    selected: null,      // currently selected release, or null = repository fallback
+    stable: [],
+    testRelease: null,
+    selected: null,
     fetched: false,
 
     hasFirmware(release) {
         return release.assets && release.assets.some(a => /\.(uf2|hex)$/i.test(a.name));
     },
 
-    // Parse a tag like "v5.0" / "V5.1.2" to a comparable number (5.0 / 5.1)
     parseVersion(tag) {
         const m = String(tag || '').match(/(\d+(?:\.\d+)?)/);
         return m ? parseFloat(m[1]) : 0;
@@ -53,8 +64,6 @@ const adapterReleases = {
             const pre = all.filter(r => r.prerelease && this.eligible(r));
             this.testRelease = pre.length ? pre[0] : null;
             this.populate();
-            // Default to the latest stable release. Firmware is distributed
-            // entirely via release assets — there is no repository fallback.
             this.select(this.stable[0] || null);
         } catch (err) {
             console.log('Error fetching adapter releases:', err.message);
@@ -93,7 +102,6 @@ const adapterReleases = {
             else this.select(this.stable.find(r => r.tag_name === tag) || null);
         };
 
-        // Hide the "Show test release" checkbox entirely when there is no test build
         const checkbox = document.getElementById('adapterShowTestRelease');
         if (checkbox) {
             const container = checkbox.closest('.test-release-toggle');
@@ -138,28 +146,20 @@ const adapterReleases = {
     select(release) {
         this.selected = release;
         this.updateInfo(release);
-        // Re-resolve the active download for the new version
-        if (wizardState.currentStep === 3) updateStep3Content();
-        if (wizardState.currentStep === 3.1) updateStep3MicroContent();
+        if (wizardState.step === 'update') updateUpdateScreen();
     },
 
     updateInfo(release) {
-        const info = document.getElementById('adapterReleaseInfo');
-        const badge = document.getElementById('adapterReleaseVersionBadge');
+        const details = document.getElementById('adapterReleaseDetails');
         const dateEl = document.getElementById('adapterReleaseDate');
         const notes = document.getElementById('adapterReleaseNotes');
-        if (!info) return;
+        if (!details) return;
 
         if (!release) {
-            // Repository fallback — no specific release metadata to show
-            info.style.display = 'none';
+            details.style.display = 'none';
             return;
         }
-        info.style.display = 'block';
-        if (badge) {
-            badge.textContent = release.tag_name;
-            badge.className = 'firmware-version' + (release.prerelease ? ' test-version' : '');
-        }
+        details.style.display = 'block';
         if (dateEl) {
             dateEl.textContent = new Date(release.published_at).toLocaleDateString('en-US', {
                 year: 'numeric', month: 'long', day: 'numeric'
@@ -167,13 +167,12 @@ const adapterReleases = {
         }
         if (notes) {
             const items = releaseBodyToItems(release.body);
-            notes.innerHTML = items.length ? `<ul>${items.join('')}</ul>` : '';
+            notes.innerHTML = items.length ? `<ul>${items.join('')}</ul>` : '<p class="no-notes">No notes for this release.</p>';
         }
     },
 
-    // Find the asset for a given base firmware name (e.g. "xiao_basic_pcb_v2")
-    // within the selected release. Asset names are tag-stamped, so match the
-    // base plus an optional "_<tag>" suffix.
+    // Find the asset for a given base firmware name within the selected release.
+    // Asset names are tag-stamped, so match the base plus an optional "_<tag>".
     findAsset(base, ext) {
         if (!this.selected || !this.selected.assets) return null;
         const re = new RegExp('^' + base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(_.+)?\\.' + ext + '$', 'i');
@@ -182,41 +181,27 @@ const adapterReleases = {
 };
 
 // Resolve the base firmware name (no extension) and extension for the current
-// board/model selection. Returns null if the selection is incomplete.
-//
-// `base` is the short, 8.3-safe asset code (e.g. "xb2" -> xb2_50.uf2). The build
-// stamps the major.minor version onto it as the release asset name. `legacyBase`
-// is the old long name (e.g. "xiao_basic_pcb_v2") so the updater keeps finding
-// assets on releases that haven't been re-stamped yet — this lets the new code
-// deploy before the existing release assets are migrated, with no broken window.
+// board/model selection. `base` is the short 8.3-safe asset code; `legacyBase`
+// keeps older, not-yet-restamped releases working.
 function getFirmwareBase() {
     if (wizardState.model === 'vail_lite') return { base: 'vl', legacyBase: 'trinkey_vail_adapter', ext: 'uf2' };
     if (wizardState.board === 'micro') return { base: 'mic', legacyBase: 'arduino_micro', ext: 'hex' };
     if (!wizardState.model || !wizardState.board) return null;
-    const p = wizardState.board === 'xiao' ? 'x' : 'q'; // short board prefix
+    const p = wizardState.board === 'xiao' ? 'x' : 'q';
     if (wizardState.model === 'basic_pcb') return { base: `${p}b2`, legacyBase: `${wizardState.board}_basic_pcb_v2`, ext: 'uf2' };
     if (wizardState.model === 'advanced_pcb') return { base: `${p}ad`, legacyBase: `${wizardState.board}_advanced_pcb`, ext: 'uf2' };
     return { base: `${p}np`, legacyBase: `${wizardState.board}_non_pcb`, ext: 'uf2' };
 }
 
 // Resolve the firmware download for the current selection + selected version.
-// Firmware comes exclusively from the selected release's tag-stamped asset.
-// .hex (Arduino Micro) is fetched in JS, so its asset URL is routed through the
-// CORS proxy; .uf2 is a direct anchor download of the GitHub asset. The asset
-// names are already short and DOS 8.3-safe (e.g. xb2_50.uf2), so the downloaded
-// file keeps GitHub's exact name — which doubles as a troubleshooting label
-// (which board/variant/version was flashed) and won't hang the Windows copy.
 function getFirmwareFile() {
     const sel = getFirmwareBase();
     if (!sel) return null;
     const { base, legacyBase, ext } = sel;
 
-    // A release must be selected, and it must carry this board's asset.
     if (!adapterReleases.selected) {
         return { unavailable: true, version: '(none)', board: `${base}.${ext}` };
     }
-    // Prefer the new short-name asset; fall back to the legacy long name for
-    // releases that haven't been re-stamped yet.
     const asset = adapterReleases.findAsset(base, ext) ||
         (legacyBase ? adapterReleases.findAsset(legacyBase, ext) : null);
     if (!asset) {
@@ -225,310 +210,654 @@ function getFirmwareFile() {
     const url = ext === 'hex'
         ? `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${adapterReleases.selected.tag_name}/${asset.name}`
         : asset.browser_download_url;
-    return { url, filename: asset.name };
+    return { url, filename: asset.name, ext };
 }
 
-// Get friendly names for display
+// Friendly names
 function getModelName(model) {
-    const names = {
-        'basic_pcb': 'Basic PCB',
-        'advanced_pcb': 'Advanced PCB',
-        'vail_lite': 'Vail Lite',
-        'non_pcb': 'DIY No PCB'
-    };
-    return names[model] || model;
+    return ({
+        basic_pcb: 'Basic PCB',
+        advanced_pcb: 'Advanced PCB',
+        vail_lite: 'Vail Lite',
+        non_pcb: 'DIY No PCB',
+    })[model] || model;
 }
 
 function getBoardName(board) {
-    const names = {
-        'qtpy': 'Adafruit QT Py SAMD21',
-        'xiao': 'Seeeduino XIAO SAMD21',
-        'micro': 'Arduino Micro (experimental)'
-    };
-    return names[board] || board;
+    return ({
+        qtpy: 'QT Py',
+        xiao: 'XIAO',
+        micro: 'Arduino Micro',
+        trinkey: 'Trinkey',
+    })[board] || board;
 }
 
-// Step navigation functions
-function goToStep(stepNumber) {
-    // Hide all steps
-    document.querySelectorAll('.wizard-step').forEach(step => {
-        step.classList.remove('active');
-    });
-
-    // Show target step. Some steps map to non-numeric section ids and all of
-    // the "Update" screens (method chooser, UF2 flow, serial flow, micro flow)
-    // light up progress dot 3.
-    let targetStepId = `step${stepNumber}`;
-    let progressStep = stepNumber;
-    if (stepNumber === 1.5) { targetStepId = 'step1_5'; }
-    else if (stepNumber === 2.5) { targetStepId = 'stepMethod'; progressStep = 3; }
-    else if (stepNumber === 3.1) { targetStepId = 'step3_micro'; progressStep = 3; }
-    else if (stepNumber === 3.2) { targetStepId = 'stepSerial'; progressStep = 3; }
-
-    const targetStep = document.getElementById(targetStepId);
-    if (targetStep) {
-        targetStep.classList.add('active');
-        wizardState.currentStep = stepNumber;
-        updateProgressBar(progressStep);
-
-        // Update step 2 content if navigating there
-        if (stepNumber === 2) {
-            updateStep2Content();
-        }
-
-        // Method chooser
-        if (stepNumber === 2.5) {
-            updateMethodContent();
-        }
-
-        // Update step 3 content if navigating there
-        if (stepNumber === 3) {
-            updateStep3Content();
-        }
-
-        // Update Micro step content if navigating there
-        if (stepNumber === 3.1) {
-            updateStep3MicroContent();
-        }
-
-        // Serial (web flasher) flow
-        if (stepNumber === 3.2) {
-            updateStepSerialContent();
-        }
-
-        // Initialize ESP flasher if navigating to step 4 (Summit)
-        if (stepNumber === 4) {
-            // Wait a moment for the DOM to update
-            setTimeout(() => {
-                if (typeof window.initializeESPFlasher === 'function') {
-                    window.initializeESPFlasher();
-                }
-            }, 100);
-        }
-    }
-}
-
-function updateStep2Content() {
-    // Show/hide QT Py hint based on model selection
-    const qtpyHint = document.getElementById('qtpyHint');
-    if (qtpyHint) {
-        if (wizardState.model === 'non_pcb') {
-            qtpyHint.style.display = 'none';
-        } else {
-            qtpyHint.style.display = 'block';
-        }
-    }
-    // The Arduino Micro is an experimental DIY/breadboard target, so its board
-    // card only appears on the "DIY No PCB" path.
-    const microCard = document.getElementById('microCard');
-    if (microCard) {
-        microCard.style.display = wizardState.model === 'non_pcb' ? '' : 'none';
-    }
-}
-
-function updateProgressBar(stepNumber) {
-    document.querySelectorAll('.progress-step').forEach(step => {
-        const stepNum = parseInt(step.dataset.step);
-        if (stepNum < stepNumber) {
-            step.classList.add('completed');
-            step.classList.remove('active');
-        } else if (stepNum === stepNumber) {
-            step.classList.add('active');
-            step.classList.remove('completed');
-        } else {
-            step.classList.remove('active', 'completed');
-        }
-    });
-}
-
-function updateStep3MicroContent() {
-    // Display the selected config on the Micro flash page
-    const configEl = document.getElementById('selectedConfigMicro');
-    if (configEl) {
-        const modelLabel = getModelName(wizardState.model) || 'DIY';
-        configEl.textContent = `${modelLabel} + ${getBoardName('micro')}`;
-    }
-}
-
-// --- Arduino Micro WebSerial flasher state ---
-const microFlasher = {
-    appPort: null,          // running-application serial port (pre-touch)
-    lastLoggedLine: '',
-};
-
-function microLog(message) {
-    console.log('[micro]', message);
-    const logArea = document.getElementById('microFlashLog');
-    if (logArea) {
-        logArea.textContent += message + '\n';
-        logArea.scrollTop = logArea.scrollHeight;
-    }
-}
-
-function microSerialLog(message) {
-    console.log('[micro-boot]', message);
-    const logArea = document.getElementById('microSerialLog');
-    if (logArea) {
-        logArea.textContent += message + '\n';
-        logArea.scrollTop = logArea.scrollHeight;
-    }
-}
-
-async function triggerMicroBootloader() {
-    if (!('serial' in navigator)) {
-        alert('WebSerial API not supported. Please use Chrome, Edge, or Opera.');
-        return;
-    }
-
-    try {
-        microSerialLog('Requesting the Arduino Micro port…');
-        const port = await navigator.serial.requestPort();
-        microSerialLog('Port selected. Performing 1200-baud touch…');
-        await window.avr109Touch1200(port);
-        microSerialLog('✅ Touch sent. The Micro should now re-enumerate as the Caterina bootloader for ~8 seconds.');
-        microSerialLog('Proceed to step 3 and select the NEW port (different COM/ttyACM number).');
-    } catch (err) {
-        microSerialLog(`❌ ${err.message}`);
-        if (err.name !== 'NotFoundError') {
-            alert(`Bootloader touch failed: ${err.message}`);
-        }
-    }
-}
-
-async function flashMicroFirmware() {
-    if (!('serial' in navigator)) {
-        alert('WebSerial API not supported. Please use Chrome, Edge, or Opera.');
-        return;
-    }
-
-    const firmware = getFirmwareFile();
-    if (!firmware) {
-        alert('No firmware file available for this configuration.');
-        return;
-    }
-    if (firmware.unavailable) {
-        alert(`Arduino Micro firmware is not available in ${firmware.version}. Choose a newer version.`);
-        return;
-    }
-
-    const progressContainer = document.getElementById('microProgressContainer');
-    const progressBar = document.getElementById('microProgressBar');
-    const progressLabel = document.getElementById('microProgressLabel');
-    const progressPercent = document.getElementById('microProgressPercent');
-
-    let port = null;
-    let flasher = null;
-
-    try {
-        microLog(`Downloading ${firmware.filename} from ${firmware.url}…`);
-        const resp = await fetch(firmware.url, { cache: 'no-cache' }).catch(() => null);
-        if (!resp || !resp.ok) {
-            throw new Error(`Firmware fetch failed: HTTP ${resp ? resp.status : 'network error'}`);
-        }
-        const hexText = await resp.text();
-        microLog(`Firmware fetched (${hexText.length} chars of Intel HEX).`);
-
-        microLog('Select the BOOTLOADER port (different from your running-app port).');
-        port = await navigator.serial.requestPort();
-
-        progressContainer.style.display = 'block';
-        progressLabel.textContent = 'Opening bootloader port…';
-
-        flasher = new window.AVR109Flasher({
-            log: microLog,
-            progress: (current, total) => {
-                const pct = Math.round((current / total) * 100);
-                progressBar.style.width = pct + '%';
-                progressPercent.textContent = `${pct}% (block ${current}/${total})`;
-                progressLabel.textContent = 'Writing firmware…';
-            },
-        });
-
-        await flasher.openPort(port, 57600);
-        await flasher.flashHex(hexText);
-
-        progressLabel.textContent = '✅ Done';
-        progressPercent.textContent = '100%';
-        progressBar.style.width = '100%';
-        alert('Firmware flashed successfully! The Micro will restart running the Vail Adapter firmware.');
-    } catch (err) {
-        microLog(`❌ Flash failed: ${err.message}`);
-        progressLabel.textContent = '❌ Error';
-        alert(`Flash failed: ${err.message}`);
-    } finally {
-        if (flasher) {
-            try { await flasher.close(); } catch (e) { /* ignore */ }
-        }
-    }
-}
-
-// Human-readable description of the current model/board selection.
 function getConfigText() {
     if (wizardState.model === 'vail_lite') return getModelName(wizardState.model);
-    return `${getModelName(wizardState.model)} + ${getBoardName(wizardState.board)}`;
+    if (wizardState.device === 'summit') return 'Vail Summit';
+    return `${getModelName(wizardState.model)} · ${getBoardName(wizardState.board)}`;
 }
 
-// Label for the currently selected release (or empty until releases load).
 function getSelectedVersionLabel() {
     const r = adapterReleases.selected;
-    return r ? (r.name || r.tag_name) : 'the selected release';
+    return r ? (r.name || r.tag_name) : 'the latest release';
 }
 
-// Method chooser: just reflect the current selection.
-function updateMethodContent() {
-    const el = document.getElementById('selectedConfigMethod');
-    if (el) el.textContent = getConfigText();
+// --- Step navigation ---------------------------------------------------------
+
+const STEP_SECTIONS = {
+    device: 'step1',
+    model: 'step1_5',
+    board: 'step2',
+    update: 'stepUpdate',
+    summit: 'step4',
+};
+
+function goToStep(step) {
+    document.querySelectorAll('.wizard-step').forEach(s => s.classList.remove('active'));
+    const section = document.getElementById(STEP_SECTIONS[step]);
+    if (!section) return;
+    section.classList.add('active');
+    wizardState.step = step;
+
+    if (step === 'board') updateBoardCards();
+    if (step === 'update') updateUpdateScreen();
+    if (step === 'summit') {
+        setTimeout(() => {
+            if (typeof window.initializeESPFlasher === 'function') window.initializeESPFlasher();
+        }, 100);
+    }
+    renderCrumbs();
+    updateHeader();
 }
 
-// Serial (web flasher) flow: reflect selection and reveal the test-only erase
-// tool when the URL hash opts in.
-function updateStepSerialContent() {
-    const el = document.getElementById('selectedConfigSerial');
-    if (el) el.textContent = `${getConfigText()} — ${getSelectedVersionLabel()}`;
+function updateHeader() {
+    const sub = document.getElementById('pageSub');
+    if (sub) sub.style.display = wizardState.step === 'device' ? '' : 'none';
+}
+
+function updateBoardCards() {
+    const qtpyHint = document.getElementById('qtpyHint');
+    if (qtpyHint) qtpyHint.style.display = wizardState.model === 'non_pcb' ? 'none' : '';
+    // The Arduino Micro is an experimental DIY target: only on the No-PCB path.
+    const microCard = document.getElementById('microCard');
+    if (microCard) microCard.style.display = wizardState.model === 'non_pcb' ? '' : 'none';
+}
+
+// Breadcrumb chips: one per decision already made, click to change it.
+function renderCrumbs() {
+    const bar = document.getElementById('crumbBar');
+    if (!bar) return;
+    const crumbs = [];
+
+    if (wizardState.device) {
+        crumbs.push({ label: wizardState.device === 'summit' ? 'Vail Summit' : 'Vail Adapter', step: 'device' });
+    }
+    if (wizardState.device === 'adapter' && wizardState.model) {
+        crumbs.push({ label: getModelName(wizardState.model), step: 'model' });
+    }
+    if (wizardState.device === 'adapter' && wizardState.board && wizardState.model !== 'vail_lite') {
+        crumbs.push({ label: getBoardName(wizardState.board), step: 'board' });
+    }
+
+    if (!crumbs.length || wizardState.step === 'device') {
+        bar.style.display = 'none';
+        return;
+    }
+
+    bar.style.display = '';
+    bar.innerHTML = '';
+    crumbs.forEach(c => {
+        const chip = document.createElement('button');
+        chip.className = 'crumb-chip';
+        chip.innerHTML = `${escapeHtml(c.label)} <span class="crumb-edit">change</span>`;
+        chip.addEventListener('click', () => goToStep(c.step));
+        bar.appendChild(chip);
+    });
+}
+
+function saveSetup() {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+            device: wizardState.device,
+            model: wizardState.model,
+            board: wizardState.board,
+            flashMethod: wizardState.flashMethod,
+        }));
+    } catch (_) { /* private mode etc. */ }
+}
+
+function loadSetup() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const s = JSON.parse(raw);
+        if (s.device === 'summit') return s;
+        if (s.device === 'adapter' && s.model) return s;
+        return null;
+    } catch (_) { return null; }
+}
+
+// --- Update screen -------------------------------------------------------------
+
+function setMethod(method) {
+    wizardState.flashMethod = method;
+    document.getElementById('tabSerial')?.classList.toggle('active', method === 'serial');
+    document.getElementById('tabUf2')?.classList.toggle('active', method === 'uf2');
+    document.getElementById('methodSerialPanel')?.classList.toggle('active', method === 'serial');
+    document.getElementById('methodUf2Panel')?.classList.toggle('active', method === 'uf2');
+    saveSetup();
+}
+
+function updateUpdateScreen() {
+    const isMicro = wizardState.board === 'micro';
+
+    // Arduino Micro flashes over serial only (Intel HEX, no UF2 bootloader).
+    const tabUf2 = document.getElementById('tabUf2');
+    if (tabUf2) tabUf2.style.display = isMicro ? 'none' : '';
+    const toggle = document.getElementById('methodToggle');
+    if (toggle) toggle.style.display = isMicro ? 'none' : '';
+
+    if (isMicro) {
+        setMethod('serial');
+    } else if (!webSerialSupported && wizardState.flashMethod === 'serial') {
+        setMethod('uf2');
+    } else {
+        setMethod(wizardState.flashMethod || (webSerialSupported ? 'serial' : 'uf2'));
+    }
+
+    // Browser-support note
+    const note = document.getElementById('noWebSerialNote');
+    if (note) note.style.display = webSerialSupported ? 'none' : '';
+    const heroBtn = document.getElementById('flashNowButton');
+    if (heroBtn) heroBtn.disabled = !webSerialSupported;
+
+    // Hero copy
+    const heroText = document.getElementById('flashHeroText');
+    if (heroText) {
+        heroText.textContent =
+            `Plug in your adapter and click once. This installs ${getSelectedVersionLabel()} on your ${getConfigText()}. ` +
+            `The first time, your browser asks which device to use. After that it's fully automatic.`;
+    }
+
+    // UF2 download link
+    updateDownloadButton();
+
+    // Test-only erase tool
     maybeRevealEraseTest();
 }
 
-function updateStep3Content() {
-    const cfg = document.getElementById('selectedConfig');
-    if (cfg) cfg.textContent = getConfigText();
-    const ver = document.getElementById('uf2VersionLabel');
-    if (ver) ver.textContent = getSelectedVersionLabel();
-
-    // Update download button
+function updateDownloadButton() {
     const downloadButton = document.getElementById('downloadButton');
     const downloadText = document.getElementById('downloadText');
+    if (!downloadButton) return;
     const firmwareFile = getFirmwareFile();
 
-    if (firmwareFile && firmwareFile.unavailable) {
-        // The selected release predates this board / has no matching asset
+    if (!firmwareFile || firmwareFile.unavailable) {
         downloadButton.removeAttribute('href');
         downloadButton.removeAttribute('download');
         downloadButton.classList.add('disabled');
         downloadButton.setAttribute('aria-disabled', 'true');
-        downloadText.textContent = `${firmwareFile.board} not available in ${firmwareFile.version}`;
-    } else if (firmwareFile) {
-        // Download the GitHub asset directly, keeping its exact (short, 8.3-safe)
-        // name so the saved file matches the release asset — useful as a
-        // troubleshooting label for which firmware was flashed.
-        const savedName = firmwareFile.filename;
+        downloadText.textContent = firmwareFile
+            ? `Not available in ${firmwareFile.version}`
+            : 'Download UF2 file';
+    } else {
         downloadButton.href = firmwareFile.url;
-        downloadButton.download = savedName;
-        downloadText.textContent = `Download ${savedName}`;
+        downloadButton.download = firmwareFile.filename;
+        downloadText.textContent = `Download ${firmwareFile.filename}`;
         downloadButton.classList.remove('disabled');
         downloadButton.removeAttribute('aria-disabled');
     }
 }
 
-// --- Web flasher: SAM-BA / BOSSA serial flashing for SAMD21 boards ----------
-// The "Web flasher" method chosen on the method screen. Flashes the selected
-// release's .uf2 directly over the bootloader's COM port — fetched via the CORS
-// proxy and converted to a raw binary — the same path the Arduino IDE uses via
-// bossac. Bypasses the UF2 drag-and-drop, which can hang on Windows.
+// --- Port intelligence ---------------------------------------------------------
+//
+// Adafruit, Seeed, and Arduino all follow the same convention: the application
+// runs on PID 0x80xx and the bootloader on the matching 0x00xx. That lets us
+// tell "running adapter" from "bootloader" without opening anything.
 
-function serialFlashLog(message) {
-    console.log('[samba]', message);
+const KNOWN_VENDORS = [
+    0x239A, // Adafruit (QT Py, Trinkey / Vail Lite)
+    0x2886, // Seeed (XIAO)
+    0x2341, // Arduino (Micro)
+    0x2A03, // Arduino.org (older Micro clones)
+    0x1B4F, // SparkFun (32U4 clones)
+];
+
+// Vendor filters for the browser's port picker, narrowed to the selected board
+// so the list doesn't fill up with Bluetooth COM ports and other serial junk.
+// The unfiltered list stays available via "Pick port manually".
+function boardFilters() {
+    const vendors = ({
+        qtpy: [0x239A],
+        trinkey: [0x239A],
+        xiao: [0x2886],
+        micro: [0x2341, 0x2A03, 0x1B4F],
+    })[wizardState.board] || KNOWN_VENDORS;
+    return vendors.map(v => ({ usbVendorId: v }));
+}
+
+function classifyPort(port) {
+    try {
+        const info = port.getInfo();
+        if (!info || !info.usbVendorId) return 'unknown';
+        if (!KNOWN_VENDORS.includes(info.usbVendorId)) return 'unknown';
+        return (info.usbProductId & 0x8000) ? 'app' : 'bootloader';
+    } catch (_) { return 'unknown'; }
+}
+
+function portLabel(port) {
+    try {
+        const i = port.getInfo();
+        if (i && i.usbVendorId) {
+            return `USB ${i.usbVendorId.toString(16).padStart(4, '0')}:${(i.usbProductId || 0).toString(16).padStart(4, '0')}`;
+        }
+    } catch (_) {}
+    return 'serial device';
+}
+
+// Open at 1200 baud and close: the "magic touch" that asks the app to reboot
+// into its bootloader. Works for SAMD21 (uf2-samdx1) and ATmega32U4 (Caterina).
+async function touch1200(port) {
+    try { await port.close(); } catch (_) { /* wasn't open */ }
+    await port.open({ baudRate: 1200 });
+    await new Promise(r => setTimeout(r, 100));
+    await port.close();
+}
+
+// After a 1200-baud touch the board re-enumerates as a different USB device.
+// If we've EVER been granted that bootloader before, it shows up in getPorts()
+// on its own — no picker. Poll for it, and also listen for the connect event.
+async function waitForBootloaderPort(previousPorts, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const ports = await navigator.serial.getPorts();
+        const found = ports.find(p => classifyPort(p) === 'bootloader') ||
+            ports.find(p => !previousPorts.includes(p));
+        if (found) return found;
+        await new Promise(r => setTimeout(r, 300));
+    }
+    return null;
+}
+
+// --- One-click flash engine ------------------------------------------------------
+
+const flashUI = {
+    stages: ['find', 'boot', 'write', 'done'],
+
+    reset() {
+        const tl = document.getElementById('flashTimeline');
+        if (tl) {
+            tl.style.display = 'none';
+            tl.querySelectorAll('li').forEach(li => li.classList.remove('active', 'done', 'error'));
+        }
+        this.progress(0, 0);
+        const track = document.getElementById('serialProgressTrack');
+        if (track) track.style.display = 'none';
+        const res = document.getElementById('flashResult');
+        if (res) { res.style.display = 'none'; res.innerHTML = ''; res.classList.remove('ok', 'err'); }
+        this.hint('');
+    },
+
+    stage(name, state) {
+        const tl = document.getElementById('flashTimeline');
+        if (!tl) return;
+        tl.style.display = '';
+        const idx = this.stages.indexOf(name);
+        tl.querySelectorAll('li').forEach(li => {
+            const i = this.stages.indexOf(li.dataset.stage);
+            li.classList.remove('active', 'error');
+            if (i < idx) li.classList.add('done');
+            if (i === idx) li.classList.add(state === 'error' ? 'error' : 'active');
+            if (i === idx && state === 'done') { li.classList.remove('active'); li.classList.add('done'); }
+        });
+    },
+
+    progress(cur, total) {
+        const bar = document.getElementById('serialFlashProgressBar');
+        const track = document.getElementById('serialProgressTrack');
+        if (!bar) return;
+        if (total > 0) {
+            if (track) track.style.display = '';
+            bar.style.width = Math.round((cur / total) * 100) + '%';
+        } else {
+            bar.style.width = '0%';
+        }
+    },
+
+    hint(text) {
+        const el = document.getElementById('flashHint');
+        if (!el) return;
+        el.style.display = text ? '' : 'none';
+        el.textContent = text || '';
+    },
+
+    result(html, ok) {
+        const res = document.getElementById('flashResult');
+        if (!res) return;
+        res.style.display = '';
+        res.classList.toggle('ok', !!ok);
+        res.classList.toggle('err', !ok);
+        res.innerHTML = html;
+    },
+
+    button(label, disabled) {
+        const btn = document.getElementById('flashNowButton');
+        if (!btn) return;
+        btn.textContent = label;
+        btn.disabled = !!disabled;
+        btn.classList.toggle('attention', /select/i.test(label));
+    },
+};
+
+function flashLog(message) {
+    console.log('[flash]', message);
     const el = document.getElementById('serialFlashLog');
     if (el) { el.textContent += message + '\n'; el.scrollTop = el.scrollHeight; }
+}
+
+const flashEngine = {
+    running: false,
+    pendingPick: null, // resolver waiting for a user click to open the picker
+
+    // Called by the hero button. Either starts a run or satisfies a pending
+    // "we need one more user gesture to show the picker" state.
+    onHeroClick() {
+        if (this.pendingPick) {
+            const resolve = this.pendingPick;
+            this.pendingPick = null;
+            resolve();
+            return;
+        }
+        if (this.running) return;
+        this.run({ manualPick: false });
+    },
+
+    // Wait for the user to click the hero button so we regain a user gesture
+    // (requestPort needs one). Used only when the bootloader device has never
+    // been granted before.
+    waitForGesture(buttonLabel, hintText) {
+        flashUI.button(buttonLabel, false);
+        flashUI.hint(hintText);
+        return new Promise(resolve => { this.pendingPick = resolve; });
+    },
+
+    async requestPortFiltered() {
+        try {
+            return await navigator.serial.requestPort({ filters: boardFilters() });
+        } catch (err) {
+            if (err.name === 'NotFoundError') {
+                // Nothing matched the filters (unusual bootloader IDs) — offer
+                // the unfiltered list once.
+                await this.waitForGesture('Select the new device', 'Your adapter was not in the list. Click to see every port.');
+                return await navigator.serial.requestPort();
+            }
+            throw err;
+        }
+    },
+
+    async run({ manualPick }) {
+        if (!webSerialSupported) return;
+        this.running = true;
+        flashUI.reset();
+        flashUI.button('Working…', true);
+
+        const isMicro = wizardState.board === 'micro';
+
+        try {
+            // Validate firmware selection up front and start the download early.
+            const firmware = getFirmwareFile();
+            if (!firmware || firmware.unavailable) {
+                throw new Error(firmware
+                    ? `This board has no firmware in ${firmware.version}. Pick a different version above.`
+                    : 'Pick a version above first.');
+            }
+            flashLog(`Fetching ${firmware.filename}…`);
+            const firmwarePromise = this.fetchFirmware(firmware);
+
+            // Stage 1: find the adapter
+            flashUI.stage('find', 'active');
+            let port = null;
+
+            if (!manualPick) {
+                const granted = await navigator.serial.getPorts();
+                port = granted.find(p => classifyPort(p) === 'bootloader') ||
+                       granted.find(p => classifyPort(p) === 'app');
+                if (port) flashLog(`Reusing remembered device (${portLabel(port)}).`);
+            }
+            if (!port) {
+                flashUI.hint('Pick your adapter in the popup. The list only shows devices that look like yours.');
+                // Filtered to the selected board's USB vendor so unrelated COM
+                // ports (Bluetooth etc.) never appear. Manual mode shows all.
+                port = manualPick
+                    ? await navigator.serial.requestPort()
+                    : await navigator.serial.requestPort({ filters: boardFilters() });
+                flashUI.hint('');
+                flashLog(`Port selected (${portLabel(port)}).`);
+            }
+
+            let cls = classifyPort(port);
+            if (manualPick && cls === 'unknown') {
+                // Manual mode: trust the user, assume it's already the bootloader.
+                cls = 'bootloader';
+            }
+            flashUI.stage('find', 'done');
+
+            // Stage 2: get into the bootloader
+            flashUI.stage('boot', 'active');
+            let bootPort = null;
+
+            if (cls === 'bootloader') {
+                flashLog('Device is already in bootloader mode.');
+                bootPort = port;
+            } else if (cls === 'unknown' && !isMicro) {
+                // Unrecognized USB IDs (DIY builds): probe SAM-BA first — it may
+                // already be a bootloader we don't recognize.
+                flashLog('Unrecognized device, probing for a bootloader…');
+                bootPort = (await this.probeSamba(port)) ? port : null;
+                if (!bootPort) {
+                    flashLog('Not a bootloader. Sending reboot command…');
+                    bootPort = await this.rebootAndReacquire(port, isMicro);
+                }
+            } else {
+                flashLog('Adapter is running normally. Sending reboot-to-bootloader command…');
+                bootPort = await this.rebootAndReacquire(port, isMicro);
+            }
+            flashUI.stage('boot', 'done');
+
+            // Stage 3: write firmware
+            flashUI.stage('write', 'active');
+            const fw = await firmwarePromise;
+            if (isMicro) {
+                await this.flashAvr109(bootPort, fw);
+            } else {
+                await this.flashSamba(bootPort, fw);
+            }
+            flashUI.stage('write', 'done');
+
+            // Done
+            flashUI.stage('done', 'done');
+            flashUI.progress(1, 1);
+            flashUI.result(
+                `<strong>Firmware installed.</strong> Your adapter is rebooting into ${escapeHtml(getSelectedVersionLabel())}. ` +
+                `Next stop: the <a href="https://vailadapter.com/gettingstarted" target="_blank" rel="noopener">Getting Started guide</a> to set keyer type, speed, and tone.`,
+                true
+            );
+            flashUI.button('Update again', false);
+        } catch (err) {
+            if (err && err.name === 'NotFoundError') {
+                flashLog('Port selection cancelled.');
+                flashUI.reset();
+                flashUI.hint('No device picked. If your adapter was missing from the list, check the cable (some only charge), or use "Pick port manually" under advanced options to see every port.');
+                flashUI.button('Update firmware', false);
+            } else {
+                flashLog(`❌ ${err.message}`);
+                const stage = document.querySelector('#flashTimeline li.active');
+                if (stage) flashUI.stage(stage.dataset.stage, 'error');
+                flashUI.result(
+                    `<strong>That didn't work.</strong> ${escapeHtml(err.message)}<br>` +
+                    `Unplug the adapter, plug it back in, and try again. The activity log under advanced options has the details, ` +
+                    `and the Download file method always works as a backup.`,
+                    false
+                );
+                flashUI.button('Try again', false);
+            }
+        } finally {
+            this.running = false;
+            this.pendingPick = null;
+        }
+    },
+
+    async fetchFirmware(firmware) {
+        const tag = adapterReleases.selected && adapterReleases.selected.tag_name;
+        const proxyUrl = `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${tag}/${firmware.filename}`;
+        const resp = await fetch(proxyUrl, { cache: 'no-cache' });
+        if (!resp.ok) throw new Error(`Firmware download failed (HTTP ${resp.status}). Check your connection and try again.`);
+        if (firmware.ext === 'hex') {
+            return { kind: 'hex', text: await resp.text() };
+        }
+        const { bin, baseAddr } = window.uf2ToBin(await resp.arrayBuffer());
+        flashLog(`Firmware ready: ${bin.length} bytes @ 0x${baseAddr.toString(16)}.`);
+        return { kind: 'bin', bin, baseAddr };
+    },
+
+    // Quick, quiet SAM-BA handshake check used for unrecognized devices.
+    async probeSamba(port) {
+        const probe = new window.SAMBAFlasher({ log: () => {} });
+        try {
+            await probe.open(port);
+            await probe.connect();
+            await probe.close();
+            return true;
+        } catch (_) {
+            try { await probe.close(); } catch (_) {}
+            return false;
+        }
+    },
+
+    // 1200-baud touch, then get the bootloader port back WITHOUT a second
+    // picker whenever possible.
+    async rebootAndReacquire(appPort, isMicro) {
+        const before = await navigator.serial.getPorts();
+        await touch1200(appPort);
+        flashLog('Reboot command sent. Waiting for the bootloader to appear…');
+        flashUI.hint('The adapter is restarting into bootloader mode…');
+
+        const found = await waitForBootloaderPort(before, isMicro ? 6000 : 8000);
+        if (found) {
+            flashUI.hint('');
+            flashLog(`Bootloader found automatically (${portLabel(found)}).`);
+            return found;
+        }
+
+        // Never-granted bootloader: we need one click to show the picker.
+        // (Chrome forgets the user gesture after a few seconds of waiting.)
+        flashLog('Bootloader needs a one-time permission grant.');
+        await this.waitForGesture(
+            'Select the new device',
+            'One more click: the adapter reappeared as a new device. Click the button, then pick it in the popup. You only do this once.'
+        );
+        flashUI.button('Working…', true);
+        const picked = await this.requestPortFiltered();
+        flashUI.hint('');
+        flashLog(`Bootloader selected (${portLabel(picked)}).`);
+        return picked;
+    },
+
+    async flashSamba(port, fw) {
+        if (fw.kind !== 'bin') throw new Error('Wrong firmware type for this board.');
+        const flasher = new window.SAMBAFlasher({
+            log: flashLog,
+            progress: (cur, total) => flashUI.progress(cur, total),
+        });
+        try {
+            await flasher.open(port);
+            await flasher.connect();
+            await flasher.eraseApp();
+            await flasher.writeFirmware(fw.bin, fw.baseAddr);
+            await flasher.resetDevice();
+        } finally {
+            try { await flasher.close(); } catch (_) {}
+        }
+    },
+
+    async flashAvr109(port, fw) {
+        if (fw.kind !== 'hex') throw new Error('Wrong firmware type for this board.');
+        const flasher = new window.AVR109Flasher({
+            log: flashLog,
+            progress: (cur, total) => flashUI.progress(cur, total),
+        });
+        try {
+            await flasher.openPort(port, 57600);
+            await flasher.flashHex(fw.text);
+        } finally {
+            try { await flasher.close(); } catch (_) {}
+        }
+    },
+};
+
+// --- Advanced tools ----------------------------------------------------------
+
+// Reboot into bootloader mode without flashing (feeds the UF2 flow too).
+// logFn/hintEl let the UF2 panel and the advanced panel share this.
+async function enterBootloaderOnly(logFn, hintElId) {
+    const hintEl = document.getElementById(hintElId);
+    const setHint = (t, ok) => {
+        if (!hintEl) return;
+        hintEl.style.display = t ? '' : 'none';
+        hintEl.textContent = t || '';
+        hintEl.classList.toggle('ok', !!ok);
+    };
+
+    if (!webSerialSupported) {
+        setHint('This browser cannot talk to USB devices. Double-tap the reset button on the adapter instead.');
+        return;
+    }
+
+    try {
+        let port = null;
+        const granted = await navigator.serial.getPorts();
+        port = granted.find(p => classifyPort(p) === 'app');
+        if (granted.find(p => classifyPort(p) === 'bootloader')) {
+            setHint('Your adapter is already in bootloader mode. The boot drive should be visible now.', true);
+            return;
+        }
+        if (port) {
+            logFn(`Reusing remembered device (${portLabel(port)}).`);
+        } else {
+            setHint('Pick your adapter in the popup.');
+            port = await navigator.serial.requestPort({ filters: boardFilters() });
+        }
+        logFn('Sending reboot-to-bootloader command (1200 baud touch)…');
+        await touch1200(port);
+        logFn('✅ Done. The boot drive (QTPYBOOT / XIAOBOOT / ADAPTERBOOT) should appear in a few seconds.');
+        setHint('Done. Watch for the boot drive to appear, then continue to the next step.', true);
+    } catch (err) {
+        if (err.name === 'NotFoundError') { setHint(''); return; }
+        logFn(`❌ ${err.message}`);
+        setHint(`That failed: ${err.message}. You can always double-tap the reset button instead.`);
+    }
+}
+
+function uf2Log(message) {
+    console.log('[uf2]', message);
+    const el = document.getElementById('serialLog');
+    if (el) { el.textContent += message + '\n'; el.scrollTop = el.scrollHeight; }
+}
+
+async function forgetRememberedPorts() {
+    const hint = document.getElementById('flashHint');
+    try {
+        const ports = await navigator.serial.getPorts();
+        let n = 0;
+        for (const p of ports) {
+            if (typeof p.forget === 'function') { await p.forget(); n++; }
+        }
+        flashLog(`Forgot ${n} remembered device${n === 1 ? '' : 's'}.`);
+        if (hint) { hint.style.display = ''; hint.textContent = `Forgot ${n} remembered device${n === 1 ? '' : 's'}. The next update will ask you to pick again.`; }
+    } catch (err) {
+        flashLog(`❌ ${err.message}`);
+    }
 }
 
 // The "Erase app" tool is test-only — reveal it only when the URL hash opts in.
@@ -537,208 +866,58 @@ function maybeRevealEraseTest() {
     if (el) el.style.display = /test|erase|debug/i.test(location.hash) ? 'block' : 'none';
 }
 
-async function flashAdapterOverSerial() {
-    if (!('serial' in navigator)) {
-        alert('WebSerial is not supported. Please use Chrome, Edge, or Opera.');
-        return;
-    }
-    const firmware = getFirmwareFile();
-    if (!firmware || firmware.unavailable) {
-        alert('Select a firmware version and board above first.');
-        return;
-    }
-    if (!firmware.filename.toLowerCase().endsWith('.uf2')) {
-        alert('Serial flashing applies to the SAMD21 boards (UF2). The Arduino Micro has its own flasher.');
-        return;
-    }
-
-    const tag = adapterReleases.selected && adapterReleases.selected.tag_name;
-    const proxyUrl = `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${tag}/${firmware.filename}`;
-
-    const container = document.getElementById('serialFlashProgressContainer');
-    const bar = document.getElementById('serialFlashProgressBar');
-    const label = document.getElementById('serialFlashProgressLabel');
-    const percent = document.getElementById('serialFlashProgressPercent');
-
-    let flasher = null;
-    try {
-        serialFlashLog(`Downloading ${firmware.filename}…`);
-        const resp = await fetch(proxyUrl, { cache: 'no-cache' });
-        if (!resp.ok) throw new Error(`Firmware download failed: HTTP ${resp.status}`);
-        const { bin, baseAddr } = window.uf2ToBin(await resp.arrayBuffer());
-        serialFlashLog(`Firmware ready: ${bin.length} bytes @ 0x${baseAddr.toString(16)}.`);
-
-        serialFlashLog("Select your adapter's bootloader COM port…");
-        const port = await navigator.serial.requestPort();
-
-        if (container) container.style.display = 'block';
-        if (label) label.textContent = 'Connecting to bootloader…';
-
-        flasher = new window.SAMBAFlasher({
-            log: serialFlashLog,
-            progress: (cur, total) => {
-                const pct = Math.round((cur / total) * 100);
-                if (bar) bar.style.width = pct + '%';
-                if (percent) percent.textContent = `${pct}% (${cur}/${total} bytes)`;
-                if (label) label.textContent = 'Writing firmware…';
-            },
-        });
-
-        await flasher.open(port);
-        await flasher.connect();
-        await flasher.eraseApp();
-        await flasher.writeFirmware(bin, baseAddr);
-        await flasher.resetDevice();
-
-        if (label) label.textContent = '✅ Done';
-        if (percent) percent.textContent = '100%';
-        if (bar) bar.style.width = '100%';
-        serialFlashLog('✅ Flash complete. The adapter should reboot into the new firmware.');
-        alert('Firmware flashed over serial! The adapter will reboot. If it stays in bootloader mode, unplug and replug it.');
-    } catch (err) {
-        serialFlashLog(`❌ ${err.message}`);
-        if (label) label.textContent = '❌ Error';
-        if (err.name !== 'NotFoundError') alert(`Serial flash failed: ${err.message}`);
-    } finally {
-        if (flasher) { try { await flasher.close(); } catch (e) { /* ignore */ } }
-    }
-}
-
 // Testing helper: erase just the app region so the bootloader finds no valid
-// app and stays in storage/bootloader mode on every power-up — i.e. reproduce
-// the "stuck" state on purpose. Fully recoverable: the bootloader (0x0000-0x2000)
-// is never erased, so "Flash over serial" or UF2 brings it back.
+// app — reproduces the "stuck in bootloader" state. Fully recoverable.
 async function eraseAdapterAppForTest() {
-    if (!('serial' in navigator)) {
-        alert('WebSerial is not supported. Please use Chrome, Edge, or Opera.');
-        return;
-    }
-    if (!confirm('TEST ONLY: this erases the adapter\'s firmware so it boots into bootloader (storage) mode every time — reproducing the "stuck" state. You can recover it with "Flash over serial" or UF2. Continue?')) {
+    if (!webSerialSupported) return;
+    if (!confirm('TEST ONLY: this erases the adapter\'s firmware so it boots into bootloader (storage) mode every time. You can recover it with the update button or a UF2 file. Continue?')) {
         return;
     }
     let flasher = null;
     try {
-        serialFlashLog("Select your adapter's bootloader COM port…");
-        const port = await navigator.serial.requestPort();
-        flasher = new window.SAMBAFlasher({ log: serialFlashLog });
+        let port = (await navigator.serial.getPorts()).find(p => classifyPort(p) === 'bootloader');
+        if (!port) {
+            flashLog("Select your adapter's bootloader COM port…");
+            port = await navigator.serial.requestPort({ filters: boardFilters() });
+        }
+        flasher = new window.SAMBAFlasher({ log: flashLog });
         await flasher.open(port);
         await flasher.connect();
         await flasher.eraseApp();
         await flasher.resetDevice();
-        serialFlashLog('✅ App erased. The adapter will now boot into bootloader mode on every plug-in until you reflash it.');
-        alert('App erased — the adapter is now in the "stuck" state (boots to bootloader/storage mode every time). Use "Flash over serial" or UF2 to recover it.');
+        flashLog('✅ App erased. The adapter now boots into bootloader mode on every plug-in until you reflash it.');
     } catch (err) {
-        serialFlashLog(`❌ ${err.message}`);
-        if (err.name !== 'NotFoundError') alert(`Erase failed: ${err.message}`);
+        flashLog(`❌ ${err.message}`);
     } finally {
-        if (flasher) { try { await flasher.close(); } catch (e) { /* ignore */ } }
+        if (flasher) { try { await flasher.close(); } catch (_) {} }
     }
 }
 
-// WebSerial boot mode functionality
-let port;
+// --- Markdown helpers for release notes ---------------------------------------
 
-// Which <pre> the bootloader-trigger logs to. The UF2 flow uses #serialLog; the
-// web-flasher flow uses #serialBootLog. Set by each boot button before calling.
-let bootLogTargetId = 'serialLog';
-
-function logToPage(message) {
-    console.log(message);
-    const logArea = document.getElementById(bootLogTargetId);
-    if (logArea) {
-        logArea.textContent += message + '\n';
-        logArea.scrollTop = logArea.scrollHeight;
-    }
-}
-
-async function triggerBootloaderViaWebSerial() {
-    logToPage("Attempting to trigger bootloader via WebSerial...");
-
-    if (!("serial" in navigator)) {
-        logToPage("Error: WebSerial API not supported by this browser. Please use Chrome, Edge, or Opera.");
-        alert("WebSerial API not supported. Please use Chrome, Edge, or Opera browser, or try the manual reset method.");
-        return;
-    }
-
-    try {
-        // Close previous port if open
-        if (port && port.readable) {
-            logToPage("Closing previously opened port...");
-            try {
-                if (port.readable) {
-                    const reader = port.readable.getReader();
-                    reader.cancel();
-                    reader.releaseLock();
-                }
-                await port.close();
-                logToPage("Previously opened port closed.");
-            } catch (closeErr) {
-                logToPage(`Note: Error closing previous port: ${closeErr.message}`);
-            }
-            port = null;
-        }
-
-        logToPage("Linux users: Select the port that represents your Arduino (e.g., /dev/ttyACM0 or /dev/ttyUSB0).");
-        logToPage("Requesting serial port selection...");
-        port = await navigator.serial.requestPort();
-        logToPage("Port selected.");
-
-        logToPage("Attempting 1200bps touch to trigger bootloader...");
-        await port.open({ baudRate: 1200 });
-        logToPage("Port opened at 1200bps.");
-
-        await port.close();
-        logToPage("Port closed after 1200bps touch.");
-        logToPage("✅ SUCCESS: Bootloader mode command sent!");
-        logToPage("Your device should now appear as a storage drive (QTPYBOOT, XIAOBOOT, or ADAPTERBOOT).");
-        alert("Bootloader mode activated! Your device should now appear as a USB storage drive. Proceed to download the firmware.");
-
-        port = null;
-
-    } catch (err) {
-        logToPage(`❌ Error: ${err.message}`);
-        if (err.name === 'NotFoundError') {
-            alert("Serial port selection cancelled or no compatible device found.");
-        } else if (err.name === 'InvalidStateError') {
-            alert("Serial port is already closed. Please try again.");
-        } else {
-            alert(`An error occurred: ${err.message}`);
-        }
-
-        if (port) {
-            try { await port.close(); } catch (e) { /* ignore */ }
-            port = null;
-        }
-    }
-}
-
-// Escape HTML special characters so release-note text can't inject markup
 function escapeHtml(s) {
-    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-// Strip the small subset of Markdown that shows up in release notes
 function stripMarkdown(s) {
     return s
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // [text](url) -> text
-        .replace(/\*\*([^*]+)\*\*/g, '$1')        // **bold** -> bold
-        .replace(/`([^`]+)`/g, '$1')              // `code` -> code
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/\*\*([^*]+)\*\*/g, '$1')
+        .replace(/`([^`]+)`/g, '$1')
         .trim();
 }
 
-// Turn a release-note body (Markdown) into <li> items for the What's New list
 function releaseBodyToItems(body) {
     const items = [];
     for (const raw of (body || '').split(/\r?\n/)) {
         const line = raw.trim();
         if (!line) continue;
-        // Skip the "Go to https://update.vailadapter.com/" promo lines
         if (/^go to\s+https?:\/\//i.test(line) || /update\.vailadapter\.com/i.test(line)) continue;
 
         const heading = line.match(/^#{1,6}\s+(.*)$/);
         if (heading) {
             const text = escapeHtml(stripMarkdown(heading[1]));
-            items.push(`<li style="list-style:none;margin-left:-20px;font-weight:600;">${text}</li>`);
+            items.push(`<li class="note-heading">${text}</li>`);
             continue;
         }
 
@@ -749,11 +928,8 @@ function releaseBodyToItems(body) {
     return items;
 }
 
-// Populate the "What's New" section from the latest GitHub Release for the
-// selected device. Both repos publish firmware as GitHub Releases; if a repo
-// has no published release yet (e.g. Summit's official channel), the section
-// is hidden rather than falling back to raw commit history.
-// deviceType: 'adapter' or 'summit'
+// --- What's New ---------------------------------------------------------------
+
 async function fetchRecentUpdates(deviceType) {
     const repoName = deviceType === 'summit' ? 'vail-summit' : 'vail-adapter';
     const deviceLabel = deviceType === 'summit' ? 'Vail Summit' : 'Vail Adapter';
@@ -762,61 +938,39 @@ async function fetchRecentUpdates(deviceType) {
     const dateElement = document.getElementById('lastUpdateDate');
     const listElement = document.getElementById('recentCommitsList');
 
-    // Update the global page title to match the selected device
     const pageTitle = document.getElementById('pageTitle');
-    if (pageTitle) {
-        pageTitle.textContent = `${deviceLabel} Firmware Update`;
-    }
+    if (pageTitle) pageTitle.textContent = `Update your ${deviceLabel}`;
 
-    // Update the device name in the header
     const deviceElement = document.getElementById('whatsNewDevice');
-    if (deviceElement) {
-        deviceElement.textContent = deviceLabel;
-    }
+    if (deviceElement) deviceElement.textContent = deviceLabel;
 
-    // Update manual link (hide for Summit since it doesn't have a manual page)
     const manualLink = document.getElementById('manualLink');
-    if (manualLink) {
-        manualLink.style.display = deviceType === 'adapter' ? 'block' : 'none';
-    }
+    if (manualLink) manualLink.style.display = deviceType === 'adapter' ? 'block' : 'none';
 
-    // Hide the "full release notes" link until this fetch resolves with a URL
     const releaseNotesLink = document.getElementById('releaseNotesLink');
     if (releaseNotesLink) releaseNotesLink.style.display = 'none';
 
-    // Show the section in a loading state, clearing any stale content from a
-    // previously selected device so the other device's notes never show through
     if (section) section.style.display = 'block';
     if (dateElement) dateElement.textContent = 'Loading...';
     if (listElement) listElement.innerHTML = '<li>Loading latest release...</li>';
 
     try {
         const response = await fetch(`https://api.github.com/repos/Vail-CW/${repoName}/releases/latest`);
-        if (response.status === 404) {
-            // No published release for this device yet — hide the section
-            if (section) section.style.display = 'none';
-            return;
-        }
         if (!response.ok) {
-            console.log('Could not fetch latest release');
             if (section) section.style.display = 'none';
             return;
         }
         const release = await response.json();
 
-        // Header: "<Version> — <date>", e.g. "V4.4 — October 3, 2025"
         const versionLabel = release.name || release.tag_name || '';
         const publishedDate = new Date(release.published_at);
         const dateStr = publishedDate.toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
+            year: 'numeric', month: 'long', day: 'numeric'
         });
         if (dateElement) {
             dateElement.textContent = versionLabel ? `${versionLabel} — ${dateStr}` : dateStr;
         }
 
-        // Body: render the release notes as a bullet list
         if (listElement) {
             const items = releaseBodyToItems(release.body);
             listElement.innerHTML = items.length
@@ -824,8 +978,6 @@ async function fetchRecentUpdates(deviceType) {
                 : '<li>See the release notes on GitHub for details.</li>';
         }
 
-        // Link to the full release notes on GitHub (nothing is silently cut off,
-        // but this is the canonical source for the complete changelog)
         if (releaseNotesLink && release.html_url) {
             const anchor = releaseNotesLink.querySelector('a');
             if (anchor) anchor.href = release.html_url;
@@ -837,199 +989,128 @@ async function fetchRecentUpdates(deviceType) {
     }
 }
 
-// Hide the What's New section and reset the page title
 function hideWhatsNew() {
     const section = document.getElementById('whatsNewSection');
-    if (section) {
-        section.style.display = 'none';
-    }
+    if (section) section.style.display = 'none';
     const pageTitle = document.getElementById('pageTitle');
-    if (pageTitle) {
-        pageTitle.textContent = 'Vail Firmware Update';
+    if (pageTitle) pageTitle.textContent = 'Update your Vail device';
+}
+
+// --- Selection handling ---------------------------------------------------------
+
+function selectDevice(device) {
+    wizardState.device = device;
+    if (device === 'adapter') {
+        fetchRecentUpdates('adapter');
+        adapterReleases.fetch();
+        goToStep('model');
+    } else {
+        wizardState.model = null;
+        wizardState.board = null;
+        fetchRecentUpdates('summit');
+        saveSetup();
+        goToStep('summit');
     }
 }
 
-// Initialize wizard on page load
+function selectModel(model) {
+    if (wizardState.model !== model) wizardState.board = null;
+    wizardState.model = model;
+    if (model === 'vail_lite') {
+        wizardState.board = 'trinkey';
+        saveSetup();
+        goToStep('update');
+    } else {
+        goToStep('board');
+    }
+}
+
+function selectBoard(board) {
+    wizardState.board = board;
+    saveSetup();
+    goToStep('update');
+}
+
+function wireCards(sectionId, dataKey, handler) {
+    document.querySelectorAll(`#${sectionId} .selection-card`).forEach(card => {
+        const pick = () => {
+            document.querySelectorAll(`#${sectionId} .selection-card`).forEach(c => c.classList.remove('selected'));
+            card.classList.add('selected');
+            handler(card.dataset[dataKey]);
+        };
+        card.addEventListener('click', pick);
+        card.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); pick(); }
+        });
+    });
+}
+
+// --- Init -----------------------------------------------------------------------
+
 document.addEventListener('DOMContentLoaded', () => {
-    // Step 1: Device selection (Adapter vs Summit)
-    document.querySelectorAll('#step1 .selection-card').forEach(card => {
-        card.addEventListener('click', () => {
-            // Remove selected state from all cards
-            document.querySelectorAll('#step1 .selection-card').forEach(c => {
-                c.classList.remove('selected');
-            });
+    wireCards('step1', 'device', selectDevice);
+    wireCards('step1_5', 'model', selectModel);
+    wireCards('step2', 'board', selectBoard);
 
-            // Mark this card as selected
-            card.classList.add('selected');
-            wizardState.device = card.dataset.device;
-
-            // Navigate based on device type
-            setTimeout(() => {
-                if (wizardState.device === 'adapter') {
-                    // Go to adapter model selection (step 1.5)
-                    goToStep(1.5);
-                    fetchRecentUpdates('adapter');
-                    adapterReleases.fetch();
-                } else if (wizardState.device === 'summit') {
-                    // Go directly to Summit flash page (step 4)
-                    goToStep(4);
-                    fetchRecentUpdates('summit');
-                }
-            }, 300);
-        });
+    // Method tabs
+    document.getElementById('tabSerial')?.addEventListener('click', () => {
+        if (webSerialSupported) setMethod('serial');
     });
+    document.getElementById('tabUf2')?.addEventListener('click', () => setMethod('uf2'));
+    document.getElementById('switchToUf2')?.addEventListener('click', () => setMethod('uf2'));
 
-    // Step 1.5: Adapter Model selection
-    document.querySelectorAll('#step1_5 .selection-card').forEach(card => {
-        card.addEventListener('click', () => {
-            // Remove selected state from all cards
-            document.querySelectorAll('#step1_5 .selection-card').forEach(c => {
-                c.classList.remove('selected');
-            });
+    // One-click flash
+    document.getElementById('flashNowButton')?.addEventListener('click', () => flashEngine.onHeroClick());
 
-            // Mark this card as selected
-            card.classList.add('selected');
-            wizardState.model = card.dataset.model;
-
-            // Vail Lite skips board selection (only one hardware variant)
-            if (wizardState.model === 'vail_lite') {
-                wizardState.board = 'trinkey'; // Set board for internal tracking
-                setTimeout(() => {
-                    goToStep(2.5); // Go to the flashing-method chooser
-                }, 300);
-            } else {
-                // Other models need board selection
-                setTimeout(() => {
-                    goToStep(2);
-                }, 300);
-            }
-        });
+    // Advanced tools
+    document.getElementById('bootOnlyButton')?.addEventListener('click', () => enterBootloaderOnly(flashLog, 'flashHint'));
+    document.getElementById('manualPortButton')?.addEventListener('click', () => {
+        if (!flashEngine.running) flashEngine.run({ manualPick: true });
     });
-
-    // Step 2: Board selection
-    document.querySelectorAll('#step2 .selection-card').forEach(card => {
-        card.addEventListener('click', () => {
-            // Remove selected state from all cards
-            document.querySelectorAll('#step2 .selection-card').forEach(c => {
-                c.classList.remove('selected');
-            });
-
-            // Mark this card as selected
-            card.classList.add('selected');
-            wizardState.board = card.dataset.board;
-
-            // Arduino Micro has its own serial-only flow; SAMD21 boards go to
-            // the flashing-method chooser (UF2 vs web flasher).
-            const nextStep = wizardState.board === 'micro' ? 3.1 : 2.5;
-            setTimeout(() => {
-                goToStep(nextStep);
-            }, 300);
-        });
-    });
-
-    // Method chooser: UF2 vs web flasher
-    document.querySelectorAll('#stepMethod .selection-card').forEach(card => {
-        card.addEventListener('click', () => {
-            document.querySelectorAll('#stepMethod .selection-card').forEach(c => c.classList.remove('selected'));
-            card.classList.add('selected');
-            wizardState.flashMethod = card.dataset.method;
-            setTimeout(() => {
-                goToStep(wizardState.flashMethod === 'serial' ? 3.2 : 3);
-            }, 300);
-        });
-    });
-
-    // Back buttons
-    document.getElementById('backToStep1FromModel')?.addEventListener('click', () => {
-        hideWhatsNew();
-        goToStep(1);
-    });
-
-    document.getElementById('backToStep1')?.addEventListener('click', () => {
-        goToStep(1.5);
-    });
-
-    // Method chooser back → board selection (or model, for Vail Lite which skips it)
-    document.getElementById('backToBoardFromMethod')?.addEventListener('click', () => {
-        goToStep(wizardState.model === 'vail_lite' ? 1.5 : 2);
-    });
-
-    // Both flow screens go back to the method chooser
-    document.getElementById('backToMethodFromUf2')?.addEventListener('click', () => goToStep(2.5));
-    document.getElementById('backToMethodFromSerial')?.addEventListener('click', () => goToStep(2.5));
-
-    document.getElementById('backToStep1FromSummit')?.addEventListener('click', () => {
-        hideWhatsNew();
-        goToStep(1);
-    });
-
-    // Start over buttons
-    document.getElementById('startOver')?.addEventListener('click', () => {
-        wizardState.device = null;
-        wizardState.model = null;
-        wizardState.board = null;
-        document.querySelectorAll('.selection-card').forEach(card => {
-            card.classList.remove('selected');
-        });
-        hideWhatsNew();
-        goToStep(1);
-    });
-
-    document.getElementById('startOverFromSummit')?.addEventListener('click', () => {
-        wizardState.device = null;
-        wizardState.model = null;
-        wizardState.board = null;
-        document.querySelectorAll('.selection-card').forEach(card => {
-            card.classList.remove('selected');
-        });
-        hideWhatsNew();
-        goToStep(1);
-    });
-
-    // Boot mode buttons (UF2 flow logs to #serialLog; serial flow to #serialBootLog)
-    document.getElementById('bootModeButton')?.addEventListener('click', () => {
-        bootLogTargetId = 'serialLog';
-        triggerBootloaderViaWebSerial();
-    });
-    document.getElementById('serialBootButton')?.addEventListener('click', () => {
-        bootLogTargetId = 'serialBootLog';
-        triggerBootloaderViaWebSerial();
-    });
-
-    // Web flasher (serial) flow
-    document.getElementById('serialFlashButton')?.addEventListener('click', flashAdapterOverSerial);
+    document.getElementById('forgetPortsButton')?.addEventListener('click', forgetRememberedPorts);
     document.getElementById('serialEraseButton')?.addEventListener('click', eraseAdapterAppForTest);
-    document.getElementById('startOverFromSerial')?.addEventListener('click', () => {
-        wizardState.device = null;
-        wizardState.model = null;
-        wizardState.board = null;
-        document.querySelectorAll('.selection-card').forEach(card => card.classList.remove('selected'));
-        hideWhatsNew();
-        goToStep(1);
+
+    // UF2 flow
+    document.getElementById('bootModeButton')?.addEventListener('click', () => enterBootloaderOnly(uf2Log, 'uf2BootHint'));
+    document.getElementById('downloadButton')?.addEventListener('click', function (event) {
+        if (this.classList.contains('disabled')) event.preventDefault();
     });
+
+    // Test-only erase tool reveal
     window.addEventListener('hashchange', maybeRevealEraseTest);
     maybeRevealEraseTest();
 
-    // Arduino Micro (WebSerial AVR109) buttons
-    document.getElementById('microBootModeButton')?.addEventListener('click', triggerMicroBootloader);
-    document.getElementById('microFlashButton')?.addEventListener('click', flashMicroFirmware);
-    document.getElementById('backToStep2FromMicro')?.addEventListener('click', () => goToStep(2));
-    document.getElementById('startOverFromMicro')?.addEventListener('click', () => {
-        wizardState.device = null;
-        wizardState.model = null;
-        wizardState.board = null;
-        document.querySelectorAll('.selection-card').forEach(card => {
-            card.classList.remove('selected');
-        });
-        hideWhatsNew();
-        goToStep(1);
-    });
+    // Quick resume from a previous visit
+    const saved = loadSetup();
+    if (saved) {
+        const card = document.getElementById('resumeCard');
+        const summary = document.getElementById('resumeSummary');
+        if (card && summary) {
+            const label = saved.device === 'summit'
+                ? 'Vail Summit'
+                : [getModelName(saved.model), saved.model === 'vail_lite' ? null : getBoardName(saved.board)].filter(Boolean).join(' · ');
+            summary.textContent = `Jump straight to updating your ${label}.`;
+            card.style.display = '';
 
-    // Download button click handler (for disabled state)
-    document.getElementById('downloadButton')?.addEventListener('click', function(event) {
-        if (this.classList.contains('disabled')) {
-            event.preventDefault();
-            alert("Please complete the previous steps first.");
+            document.getElementById('resumeButton')?.addEventListener('click', () => {
+                card.style.display = 'none';
+                wizardState.device = saved.device;
+                wizardState.model = saved.model;
+                wizardState.board = saved.board;
+                wizardState.flashMethod = saved.flashMethod || 'serial';
+                if (saved.device === 'summit') {
+                    fetchRecentUpdates('summit');
+                    goToStep('summit');
+                } else {
+                    fetchRecentUpdates('adapter');
+                    adapterReleases.fetch();
+                    goToStep('update');
+                }
+            });
+            document.getElementById('resumeDismiss')?.addEventListener('click', () => {
+                card.style.display = 'none';
+                try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+            });
         }
-    });
+    }
 });

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -235,6 +235,7 @@ function getBoardName(board) {
 function getConfigText() {
     if (wizardState.model === 'vail_lite') return getModelName(wizardState.model);
     if (wizardState.device === 'summit') return 'Vail Summit';
+    if (!wizardState.board) return getModelName(wizardState.model);
     return `${getModelName(wizardState.model)} · ${getBoardName(wizardState.board)}`;
 }
 
@@ -247,8 +248,7 @@ function getSelectedVersionLabel() {
 
 const STEP_SECTIONS = {
     device: 'step1',
-    model: 'step1_5',
-    board: 'step2',
+    model: 'stepModel',
     update: 'stepUpdate',
     summit: 'step4',
 };
@@ -260,7 +260,12 @@ function goToStep(step) {
     section.classList.add('active');
     wizardState.step = step;
 
-    if (step === 'board') updateBoardCards();
+    // The quick-resume card only makes sense before any choice is made.
+    if (step !== 'device') {
+        const resume = document.getElementById('resumeCard');
+        if (resume) resume.style.display = 'none';
+    }
+
     if (step === 'update') updateUpdateScreen();
     if (step === 'summit') {
         setTimeout(() => {
@@ -276,14 +281,6 @@ function updateHeader() {
     if (sub) sub.style.display = wizardState.step === 'device' ? '' : 'none';
 }
 
-function updateBoardCards() {
-    const qtpyHint = document.getElementById('qtpyHint');
-    if (qtpyHint) qtpyHint.style.display = wizardState.model === 'non_pcb' ? 'none' : '';
-    // The Arduino Micro is an experimental DIY target: only on the No-PCB path.
-    const microCard = document.getElementById('microCard');
-    if (microCard) microCard.style.display = wizardState.model === 'non_pcb' ? '' : 'none';
-}
-
 // Breadcrumb chips: one per decision already made, click to change it.
 function renderCrumbs() {
     const bar = document.getElementById('crumbBar');
@@ -294,10 +291,10 @@ function renderCrumbs() {
         crumbs.push({ label: wizardState.device === 'summit' ? 'Vail Summit' : 'Vail Adapter', step: 'device' });
     }
     if (wizardState.device === 'adapter' && wizardState.model) {
-        crumbs.push({ label: getModelName(wizardState.model), step: 'model' });
-    }
-    if (wizardState.device === 'adapter' && wizardState.board && wizardState.model !== 'vail_lite') {
-        crumbs.push({ label: getBoardName(wizardState.board), step: 'board' });
+        const label = wizardState.model === 'vail_lite' || !wizardState.board
+            ? getModelName(wizardState.model)
+            : `${getModelName(wizardState.model)} · ${getBoardName(wizardState.board)}`;
+        crumbs.push({ label, step: 'model' });
     }
 
     if (!crumbs.length || wizardState.step === 'device') {
@@ -370,14 +367,25 @@ function updateUpdateScreen() {
     const note = document.getElementById('noWebSerialNote');
     if (note) note.style.display = webSerialSupported ? 'none' : '';
     const heroBtn = document.getElementById('flashNowButton');
-    if (heroBtn) heroBtn.disabled = !webSerialSupported;
+    if (heroBtn && !flashEngine.running) heroBtn.disabled = !webSerialSupported;
 
     // Hero copy
     const heroText = document.getElementById('flashHeroText');
     if (heroText) {
         heroText.textContent =
             `Plug in your adapter and click once. This installs ${getSelectedVersionLabel()} on your ${getConfigText()}. ` +
-            `The first time, your browser asks which device to use. After that it's fully automatic.`;
+            `The exact board inside is detected automatically. The first time, your browser asks which device to use. After that it's fully automatic.`;
+    }
+
+    // UF2 fallback board chips: shown for models where the board matters and
+    // hasn't been detected as something UF2 can't serve (micro).
+    const row = document.getElementById('uf2BoardRow');
+    if (row) {
+        const needsBoard = wizardState.model && wizardState.model !== 'vail_lite' && !isMicro;
+        row.style.display = needsBoard ? '' : 'none';
+        row.querySelectorAll('.board-pick').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.board === wizardState.board);
+        });
     }
 
     // UF2 download link
@@ -400,7 +408,7 @@ function updateDownloadButton() {
         downloadButton.setAttribute('aria-disabled', 'true');
         downloadText.textContent = firmwareFile
             ? `Not available in ${firmwareFile.version}`
-            : 'Download UF2 file';
+            : (wizardState.model && !wizardState.board ? 'Pick your board above first' : 'Download UF2 file');
     } else {
         downloadButton.href = firmwareFile.url;
         downloadButton.download = firmwareFile.filename;
@@ -424,17 +432,45 @@ const KNOWN_VENDORS = [
     0x1B4F, // SparkFun (32U4 clones)
 ];
 
-// Vendor filters for the browser's port picker, narrowed to the selected board
-// so the list doesn't fill up with Bluetooth COM ports and other serial junk.
+// Vendor filters for the browser's port picker, so the list doesn't fill up
+// with Bluetooth COM ports and other serial junk. Narrowed to the board once
+// it's known, otherwise to what the selected model could plausibly contain.
 // The unfiltered list stays available via "Pick port manually".
 function boardFilters() {
-    const vendors = ({
+    const byBoard = ({
         qtpy: [0x239A],
         trinkey: [0x239A],
         xiao: [0x2886],
         micro: [0x2341, 0x2A03, 0x1B4F],
-    })[wizardState.board] || KNOWN_VENDORS;
-    return vendors.map(v => ({ usbVendorId: v }));
+    })[wizardState.board];
+    const byModel = ({
+        basic_pcb: [0x239A, 0x2886],
+        advanced_pcb: [0x239A, 0x2886],
+        vail_lite: [0x239A],
+        non_pcb: KNOWN_VENDORS,
+    })[wizardState.model];
+    return (byBoard || byModel || KNOWN_VENDORS).map(v => ({ usbVendorId: v }));
+}
+
+// The board is fully identified by the USB vendor id, so nobody has to know
+// what's soldered inside their adapter.
+function detectBoardFromPort(port) {
+    try {
+        const info = port.getInfo();
+        if (!info || !info.usbVendorId) return null;
+        if (info.usbVendorId === 0x2886) return 'xiao';
+        if ([0x2341, 0x2A03, 0x1B4F].includes(info.usbVendorId)) return 'micro';
+        if (info.usbVendorId === 0x239A) return wizardState.model === 'vail_lite' ? 'trinkey' : 'qtpy';
+        return null;
+    } catch (_) { return null; }
+}
+
+function boardDetected(board, viaLabel) {
+    wizardState.board = board;
+    saveSetup();
+    renderCrumbs();
+    flashLog(`Detected board: ${getBoardName(board)}${viaLabel ? ` (${viaLabel})` : ''}.`);
+    if (wizardState.step === 'update') updateUpdateScreen();
 }
 
 function classifyPort(port) {
@@ -582,6 +618,29 @@ const flashEngine = {
         return new Promise(resolve => { this.pendingPick = resolve; });
     },
 
+    // Last-resort inline question for DIY builds whose USB IDs we don't
+    // recognize. Renders board buttons in the hint area and waits.
+    askBoardInline() {
+        return new Promise(resolve => {
+            const el = document.getElementById('flashHint');
+            if (!el) { resolve('qtpy'); return; }
+            el.style.display = '';
+            el.innerHTML = 'This device doesn\'t identify itself, which board is it? ' +
+                '<span class="hint-board-btns">' +
+                '<button type="button" class="board-pick" data-board="qtpy">QT Py</button> ' +
+                '<button type="button" class="board-pick" data-board="xiao">XIAO</button> ' +
+                '<button type="button" class="board-pick" data-board="micro">Micro</button>' +
+                '</span>';
+            el.querySelectorAll('.board-pick').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    el.innerHTML = '';
+                    el.style.display = 'none';
+                    resolve(btn.dataset.board);
+                });
+            });
+        });
+    },
+
     async requestPortFiltered() {
         try {
             return await navigator.serial.requestPort({ filters: boardFilters() });
@@ -602,18 +661,10 @@ const flashEngine = {
         flashUI.reset();
         flashUI.button('Working…', true);
 
-        const isMicro = wizardState.board === 'micro';
-
         try {
-            // Validate firmware selection up front and start the download early.
-            const firmware = getFirmwareFile();
-            if (!firmware || firmware.unavailable) {
-                throw new Error(firmware
-                    ? `This board has no firmware in ${firmware.version}. Pick a different version above.`
-                    : 'Pick a version above first.');
+            if (!adapterReleases.selected) {
+                throw new Error('Pick a version above first.');
             }
-            flashLog(`Fetching ${firmware.filename}…`);
-            const firmwarePromise = this.fetchFirmware(firmware);
 
             // Stage 1: find the adapter
             flashUI.stage('find', 'active');
@@ -627,14 +678,41 @@ const flashEngine = {
             }
             if (!port) {
                 flashUI.hint('Pick your adapter in the popup. The list only shows devices that look like yours.');
-                // Filtered to the selected board's USB vendor so unrelated COM
-                // ports (Bluetooth etc.) never appear. Manual mode shows all.
+                // Filtered so unrelated COM ports (Bluetooth etc.) never
+                // appear. Manual mode shows everything.
                 port = manualPick
                     ? await navigator.serial.requestPort()
                     : await navigator.serial.requestPort({ filters: boardFilters() });
                 flashUI.hint('');
                 flashLog(`Port selected (${portLabel(port)}).`);
             }
+
+            // The USB vendor id tells us exactly which board is inside, so the
+            // right firmware is chosen without asking.
+            const detected = detectBoardFromPort(port);
+            if (detected) {
+                boardDetected(detected, portLabel(port));
+            } else if (!wizardState.board) {
+                // Unrecognized USB IDs and no earlier choice (DIY clones):
+                // ask inline, once.
+                wizardState.board = await this.askBoardInline();
+                saveSetup();
+                renderCrumbs();
+                updateUpdateScreen();
+                flashLog(`Board set manually: ${getBoardName(wizardState.board)}.`);
+            }
+            const isMicro = wizardState.board === 'micro';
+            if (isMicro) flashLog('Note: Arduino Micro support is experimental.');
+
+            // Now that the board is known, resolve and fetch the firmware.
+            const firmware = getFirmwareFile();
+            if (!firmware || firmware.unavailable) {
+                throw new Error(firmware
+                    ? `This board has no firmware in ${firmware.version}. Pick a different version above.`
+                    : 'Pick a version above first.');
+            }
+            flashLog(`Fetching ${firmware.filename}…`);
+            const firmwarePromise = this.fetchFirmware(firmware);
 
             let cls = classifyPort(port);
             if (manualPick && cls === 'unknown') {
@@ -828,6 +906,15 @@ async function enterBootloaderOnly(logFn, hintElId) {
             setHint('Pick your adapter in the popup.');
             port = await navigator.serial.requestPort({ filters: boardFilters() });
         }
+        // A port in hand also tells us the board, which fills in the download.
+        const detected = detectBoardFromPort(port);
+        if (detected && detected !== wizardState.board) {
+            wizardState.board = detected;
+            saveSetup();
+            renderCrumbs();
+            logFn(`Detected board: ${getBoardName(detected)}.`);
+            if (wizardState.step === 'update') updateUpdateScreen();
+        }
         logFn('Sending reboot-to-bootloader command (1200 baud touch)…');
         await touch1200(port);
         logFn('✅ Done. The boot drive (QTPYBOOT / XIAOBOOT / ADAPTERBOOT) should appear in a few seconds.');
@@ -1013,20 +1100,12 @@ function selectDevice(device) {
     }
 }
 
+// Only the model is asked. The board inside is detected from USB IDs when a
+// port is picked (see detectBoardFromPort); Vail Lite is its own hardware.
 function selectModel(model) {
     if (wizardState.model !== model) wizardState.board = null;
     wizardState.model = model;
-    if (model === 'vail_lite') {
-        wizardState.board = 'trinkey';
-        saveSetup();
-        goToStep('update');
-    } else {
-        goToStep('board');
-    }
-}
-
-function selectBoard(board) {
-    wizardState.board = board;
+    if (model === 'vail_lite') wizardState.board = 'trinkey';
     saveSetup();
     goToStep('update');
 }
@@ -1049,8 +1128,17 @@ function wireCards(sectionId, dataKey, handler) {
 
 document.addEventListener('DOMContentLoaded', () => {
     wireCards('step1', 'device', selectDevice);
-    wireCards('step1_5', 'model', selectModel);
-    wireCards('step2', 'board', selectBoard);
+    wireCards('stepModel', 'model', selectModel);
+
+    // UF2 fallback board chips (only needed when detection hasn't run,
+    // e.g. browsers without WebSerial)
+    document.querySelectorAll('#uf2BoardRow .board-pick').forEach(btn => {
+        btn.addEventListener('click', () => {
+            wizardState.board = btn.dataset.board;
+            saveSetup();
+            updateUpdateScreen();
+        });
+    });
 
     // Method tabs
     document.getElementById('tabSerial')?.addEventListener('click', () => {

--- a/online-updater/style.css
+++ b/online-updater/style.css
@@ -23,8 +23,8 @@
     --red-soft: rgba(238, 108, 90, 0.12);
     --radius: 6px;
     --radius-sm: 4px;
-    --display: 'Chakra Petch', 'Segoe UI', sans-serif;
-    --mono: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+    --display: 'Courier Prime', 'Courier New', ui-monospace, monospace;
+    --mono: 'Courier Prime', 'Courier New', ui-monospace, monospace;
     --body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
 }
 
@@ -81,7 +81,7 @@ nav {
     font-family: var(--display);
     font-weight: 700;
     font-size: 0.98rem;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.08em;
     color: var(--text);
 }
 
@@ -357,6 +357,54 @@ h4 { color: var(--text-dim); font-size: 0.95rem; margin-top: 0.5rem; }
     margin: 0;
     line-height: 1.45;
 }
+
+/* Small board chips (UF2 fallback + inline detection question) */
+.board-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin: 0 0 0.85rem;
+    align-items: center;
+}
+
+.board-row-label {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    width: 100%;
+}
+
+.board-pick {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    background: var(--panel-3);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.board-pick:hover, .board-pick:focus-visible {
+    border-color: var(--amber);
+    color: var(--amber-bright);
+    background: var(--amber-soft);
+    outline: none;
+}
+
+.board-pick.active {
+    border-color: var(--amber);
+    background: var(--amber);
+    color: #1c1204;
+}
+
+.hint-board-btns { display: inline-flex; gap: 0.4rem; margin-left: 0.4rem; }
 
 .hint {
     margin-top: 0.75rem;

--- a/online-updater/style.css
+++ b/online-updater/style.css
@@ -75,36 +75,12 @@ nav {
 
 .nav-brand:hover { text-decoration: none; }
 
-.brand-stack { display: flex; flex-direction: column; gap: 2px; line-height: 1.05; }
-
 .brand-word {
     font-family: var(--display);
     font-weight: 700;
     font-size: 0.98rem;
     letter-spacing: 0.08em;
     color: var(--text);
-}
-
-.brand-morse {
-    display: block;
-    color: var(--amber);
-    opacity: 0.9;
-    margin-top: 1px;
-}
-
-.brand-dot {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    background: var(--amber);
-    box-shadow: 0 0 10px rgba(240, 166, 60, 0.9);
-    animation: lamp 3.2s steps(1) infinite;
-}
-
-@keyframes lamp {
-    0%, 82% { opacity: 1; }
-    86%, 90% { opacity: 0.25; }
-    94%, 100% { opacity: 1; }
 }
 
 nav ul {

--- a/online-updater/style.css
+++ b/online-updater/style.css
@@ -1,955 +1,1164 @@
-/* General Body & Typography */
+/* Vail Updater — "telegraph instrument" theme
+   Warm near-black panel board, signal-amber controls, morse-code motifs.
+   Shared by index.html and troubleshoot.html, so legacy class names
+   (flash-step, step-badge, btn-*, log-container, …) are kept and restyled. */
+
+:root {
+    --bg: #12100c;
+    --panel: #1a1712;
+    --panel-2: #211d16;
+    --panel-3: #2a2419;
+    --border: #2e2921;
+    --border-strong: #463c2b;
+    --text: #ece3d2;
+    --text-dim: #c9bda5;
+    --muted: #93876f;
+    --amber: #f0a63c;
+    --amber-bright: #ffc257;
+    --amber-deep: #8a5c14;
+    --amber-soft: rgba(240, 166, 60, 0.12);
+    --green: #8fca6f;
+    --green-soft: rgba(143, 202, 111, 0.12);
+    --red: #ee6c5a;
+    --red-soft: rgba(238, 108, 90, 0.12);
+    --radius: 6px;
+    --radius-sm: 4px;
+    --display: 'Chakra Petch', 'Segoe UI', sans-serif;
+    --mono: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+    --body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
 html, body {
     margin: 0;
     padding: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
-    line-height: 1.6;
-    background: linear-gradient(135deg, #1e1e1e 0%, #2d2d2d 100%);
-    color: #e0e0e0;
+    font-family: var(--body);
+    line-height: 1.55;
+    background:
+        radial-gradient(900px 380px at 50% -8%, rgba(240, 166, 60, 0.07), transparent 65%),
+        radial-gradient(rgba(236, 227, 210, 0.045) 1px, transparent 1.3px),
+        var(--bg);
+    background-size: auto, 26px 26px, auto;
+    color: var(--text);
     min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
 }
 
-/* Container/Wrapper */
+/* ---------- Navigation ---------- */
+
+nav {
+    border-bottom: 1px solid var(--border);
+    background: rgba(18, 16, 12, 0.88);
+    backdrop-filter: blur(8px);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+}
+
+.nav-inner {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0.55rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.nav-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    text-decoration: none;
+}
+
+.nav-brand:hover { text-decoration: none; }
+
+.brand-stack { display: flex; flex-direction: column; gap: 2px; line-height: 1.05; }
+
+.brand-word {
+    font-family: var(--display);
+    font-weight: 700;
+    font-size: 0.98rem;
+    letter-spacing: 0.14em;
+    color: var(--text);
+}
+
+.brand-morse {
+    display: block;
+    color: var(--amber);
+    opacity: 0.9;
+    margin-top: 1px;
+}
+
+.brand-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 10px rgba(240, 166, 60, 0.9);
+    animation: lamp 3.2s steps(1) infinite;
+}
+
+@keyframes lamp {
+    0%, 82% { opacity: 1; }
+    86%, 90% { opacity: 0.25; }
+    94%, 100% { opacity: 1; }
+}
+
+nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0.4rem 0;
+    display: flex;
+    justify-content: center;
+    gap: 0.15rem;
+}
+
+nav ul li { display: inline; margin: 0; }
+
+nav ul li a {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: var(--radius-sm);
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+nav ul li a:hover {
+    color: var(--amber-bright);
+    background-color: var(--amber-soft);
+    text-decoration: none;
+}
+
+/* ---------- Layout ---------- */
+
 .container {
-    width: 90%;
-    max-width: 1000px;
-    margin: 2rem auto;
-    padding: 2.5rem;
-    background-color: #2c2c2c;
-    border-radius: 16px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 4rem;
 }
 
-/* Headings */
+.page-header { margin-bottom: 1.25rem; }
+
 h1 {
-    text-align: center;
-    color: #6cb2f7;
-    margin-bottom: 2rem;
-    font-size: 2.5rem;
-    font-weight: 600;
+    font-family: var(--display);
+    color: var(--text);
+    margin: 0 0 0.3rem;
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    text-align: left;
 }
+
+.page-sub { margin: 0; color: var(--muted); font-size: 0.98rem; }
 
 h2 {
-    color: #5cadff;
-    margin-top: 0;
-    margin-bottom: 1rem;
-    font-size: 1.8rem;
-    font-weight: 500;
-}
-
-h3 {
-    color: #e0e0e0;
-    font-size: 1.3rem;
-    font-weight: 500;
-    margin-top: 1rem;
-}
-
-h4 {
-    color: #c0c0c0;
-    font-size: 1.1rem;
-    margin-top: 0.5rem;
-}
-
-/* Progress Bar */
-.progress-bar {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 3rem;
-    padding: 0 1rem;
-}
-
-.progress-step {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    position: relative;
-}
-
-.step-number {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    background-color: #484848;
-    color: #888;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    font-family: var(--display);
+    color: var(--text);
+    margin: 0 0 1.1rem;
+    font-size: 1.25rem;
     font-weight: 600;
-    font-size: 1.2rem;
-    transition: all 0.3s ease;
+    letter-spacing: 0.02em;
 }
 
-.progress-step.active .step-number {
-    background-color: #0d6efd;
-    color: white;
-    box-shadow: 0 0 20px rgba(13, 110, 253, 0.5);
-}
-
-.progress-step.completed .step-number {
-    background-color: #28a745;
-    color: white;
-}
-
-.progress-step.completed .step-number::after {
-    content: '✓';
-    position: absolute;
-}
-
-.step-label {
-    font-size: 0.9rem;
-    color: #888;
-    font-weight: 500;
-}
-
-.progress-step.active .step-label,
-.progress-step.completed .step-label {
-    color: #e0e0e0;
-}
-
-.progress-line {
-    width: 100px;
-    height: 3px;
-    background-color: #484848;
-    margin: 0 1rem;
-}
-
-/* Wizard Steps */
-.wizard-step {
-    display: none;
-    animation: fadeIn 0.4s ease;
-}
-
-.wizard-step.active {
+/* Morse rule under section headings: dah-dit-dah in amber */
+.wizard-step h2::after {
+    content: '';
     display: block;
+    margin-top: 0.5rem;
+    width: 74px;
+    height: 3px;
+    background:
+        linear-gradient(90deg,
+            var(--amber) 0 22px, transparent 22px 30px,
+            var(--amber) 30px 36px, transparent 36px 44px,
+            var(--amber) 44px 66px, transparent 66px);
+    border-radius: 2px;
 }
 
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
+h3 { color: var(--text); font-size: 1.02rem; font-weight: 600; margin-top: 1rem; }
+h4 { color: var(--text-dim); font-size: 0.95rem; margin-top: 0.5rem; }
 
 .step-description {
-    color: #aaa;
-    font-size: 1.1rem;
-    margin-bottom: 2rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+    margin: -0.5rem 0 1.25rem;
 }
 
-/* Selection Cards */
+/* ---------- Breadcrumbs (terminal path) ---------- */
+
+.crumb-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.1rem;
+    margin-bottom: 1.25rem;
+    font-family: var(--mono);
+}
+
+.crumb-bar::before {
+    content: '>';
+    color: var(--amber);
+    font-weight: 600;
+    margin-right: 0.45rem;
+}
+
+.crumb-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    padding: 0.25rem 0.5rem;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--text-dim);
+    font-family: var(--mono);
+    font-size: 0.82rem;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.crumb-chip + .crumb-chip::before {
+    content: '/';
+    color: var(--border-strong);
+    margin-right: 0.45rem;
+}
+
+.crumb-chip:hover { color: var(--amber-bright); background: var(--amber-soft); }
+
+.crumb-edit {
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: var(--amber);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.crumb-chip:hover .crumb-edit { opacity: 1; }
+
+/* ---------- Resume card ---------- */
+
+.resume-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius);
+    padding: 0.85rem 1.1rem;
+    margin-bottom: 1.25rem;
+}
+
+.resume-text { color: var(--text-dim); font-size: 0.95rem; }
+.resume-text strong { color: var(--amber-bright); margin-right: 0.35rem; font-family: var(--display); letter-spacing: 0.03em; }
+.resume-actions { display: flex; gap: 0.5rem; }
+
+/* ---------- Wizard steps ---------- */
+
+.wizard-step { display: none; animation: rise 0.25s ease; }
+.wizard-step.active { display: block; }
+
+@keyframes rise {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+}
+
+/* ---------- Selection cards ---------- */
+
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 0.9rem;
+    margin-bottom: 1.5rem;
 }
 
 .selection-card {
-    background-color: #383838;
-    border: 2px solid #484848;
-    border-radius: 12px;
-    padding: 2rem;
-    text-align: center;
+    position: relative;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.1rem 1.2rem;
+    text-align: left;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.selection-card:hover {
-    border-color: #0d6efd;
-    transform: translateY(-5px);
-    box-shadow: 0 8px 24px rgba(13, 110, 253, 0.2);
+/* Blueprint corner tick, revealed on hover */
+.selection-card::after {
+    content: '';
+    position: absolute;
+    top: -1px;
+    right: -1px;
+    width: 14px;
+    height: 14px;
+    border-top: 2px solid transparent;
+    border-right: 2px solid transparent;
+    border-top-right-radius: var(--radius);
+    transition: border-color 0.15s ease;
 }
+
+.selection-card:hover, .selection-card:focus-visible {
+    border-color: var(--border-strong);
+    background: var(--panel-2);
+    outline: none;
+}
+
+.selection-card:hover::after, .selection-card:focus-visible::after,
+.selection-card.selected::after { border-color: var(--amber); }
 
 .selection-card.selected {
-    border-color: #0d6efd;
-    background-color: #2d4a7c;
-    box-shadow: 0 8px 24px rgba(13, 110, 253, 0.3);
+    border-color: var(--amber);
+    background: linear-gradient(160deg, var(--amber-soft), transparent 55%), var(--panel);
 }
 
 .card-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    font-size: 1.25rem;
+    background: var(--panel-3);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    margin-bottom: 0.65rem;
+    filter: saturate(0.55);
 }
 
 .selection-card h3 {
-    margin: 0.5rem 0;
-    color: #fff;
+    margin: 0 0 0.3rem;
+    color: var(--text);
+    font-family: var(--display);
+    font-size: 1rem;
+    letter-spacing: 0.02em;
 }
 
 .selection-card p {
-    color: #aaa;
-    font-size: 0.95rem;
-    margin-bottom: 0;
+    color: var(--muted);
+    font-size: 0.88rem;
+    margin: 0;
+    line-height: 1.45;
 }
 
 .hint {
-    margin-top: 1rem;
-    padding: 0.5rem;
-    background-color: rgba(255, 193, 7, 0.1);
-    border-radius: 6px;
-    color: #ffc107;
-    font-size: 0.9rem;
+    margin-top: 0.75rem;
+    padding: 0.45rem 0.6rem;
+    background: var(--amber-soft);
+    border-radius: var(--radius-sm);
+    color: var(--amber-bright);
+    font-size: 0.8rem;
     font-weight: 500;
+    line-height: 1.4;
 }
 
-/* Info Box */
-.info-box {
-    background: linear-gradient(135deg, #1e3a5f 0%, #2d4a7c 100%);
-    border-left: 4px solid #0d6efd;
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 2rem;
+.hint.warn { background: var(--red-soft); color: var(--red); }
+
+/* ---------- Panels ---------- */
+
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.15rem;
+    margin-bottom: 1rem;
 }
 
-.info-box h3 {
-    margin-top: 0;
-    color: #6cb2f7;
+.panel-row {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    flex-wrap: wrap;
 }
 
-.info-box ul {
-    margin: 1rem 0;
+.panel-label {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--amber);
 }
 
-.info-box li {
-    margin-bottom: 0.5rem;
-}
-
-.info-box a {
-    color: #6cb2f7;
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.info-box a:hover {
-    text-decoration: underline;
-}
-
-/* Flash Steps */
+/* Legacy step blocks (troubleshoot.html) */
 .flash-step {
-    background-color: #383838;
-    border-radius: 12px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-    border: 1px solid #484848;
+    background: var(--panel);
+    border-radius: var(--radius);
+    padding: 1.15rem 1.25rem;
+    margin-bottom: 1rem;
+    border: 1px solid var(--border);
 }
 
 .step-header {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
 }
 
 .step-badge {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background-color: #0d6efd;
-    color: white;
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    border-radius: var(--radius-sm);
+    background: var(--panel-3);
+    color: var(--amber-bright);
+    border: 1px solid var(--border-strong);
     display: flex;
     align-items: center;
     justify-content: center;
+    font-family: var(--mono);
     font-weight: 600;
-    font-size: 1.2rem;
-}
-
-.step-header h3 {
-    margin: 0;
-}
-
-/* Boot Methods */
-.boot-methods {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1rem;
-}
-
-.boot-method {
-    background-color: #2c2c2c;
-    border-radius: 8px;
-    padding: 1.5rem;
-    border: 1px solid #484848;
-}
-
-.boot-method h4 {
-    color: #6cb2f7;
-    margin-top: 0;
-}
-
-/* Log Container */
-.log-container {
-    margin-top: 1rem;
-}
-
-.log-container h4 {
-    font-size: 0.9rem;
-    margin-bottom: 0.5rem;
-}
-
-#serialLog, #espFlashLog {
-    background-color: #1a1a1a !important;
-    color: #d0d0d0 !important;
-    border: 1px solid #444 !important;
-    padding: 1rem;
-    border-radius: 6px;
-    max-height: 300px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-family: 'Courier New', monospace;
     font-size: 0.85rem;
 }
 
-#serialLog {
-    height: 150px;
+.step-header h3 { margin: 0; font-family: var(--display); }
+
+/* ---------- Method toggle (instrument switch) ---------- */
+
+.method-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-bottom: 1rem;
+    background: var(--panel);
 }
 
-/* Buttons */
-.btn-primary, .btn-secondary, .btn-download {
-    display: inline-block;
-    padding: 12px 28px;
-    font-size: 1rem;
-    font-weight: 500;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    text-decoration: none;
-    text-align: center;
-}
-
-button.btn-primary, button.btn-secondary, button#bootModeButton {
-    width: auto;
-}
-
-.btn-primary, #bootModeButton {
-    background-color: #0d6efd;
-    color: white;
-}
-
-.btn-primary:hover, #bootModeButton:hover {
-    background-color: #0b5ed7;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(13, 110, 253, 0.4);
-}
-
-.btn-secondary {
-    background-color: #6c757d;
-    color: white;
-    margin-right: 1rem;
-}
-
-.btn-secondary:hover {
-    background-color: #5a6268;
-}
-
-.btn-download {
-    background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
-    color: white;
-    font-size: 1.1rem;
-    padding: 16px 32px;
+.method-tab {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.55rem;
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.65rem 1.2rem;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.btn-download:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(40, 167, 69, 0.4);
+.method-tab + .method-tab { border-left: 1px solid var(--border-strong); }
+
+.method-tab::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    border: 1px solid var(--border-strong);
+    background: transparent;
+    transition: all 0.15s ease;
 }
 
-.btn-download.disabled {
-    background: #555;
-    color: #aaa;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
+.method-tab:hover { color: var(--text); }
+
+.method-tab.active {
+    background: var(--panel-3);
+    color: var(--amber-bright);
 }
 
-.download-icon {
-    font-size: 1.3rem;
+.method-tab.active::before {
+    background: var(--amber);
+    border-color: var(--amber);
+    box-shadow: 0 0 8px rgba(240, 166, 60, 0.9);
 }
 
-/* Success Message */
-.success-message {
-    background-color: rgba(40, 167, 69, 0.1);
-    border: 2px solid #28a745;
-    border-radius: 8px;
-    padding: 1rem;
-    margin-top: 1rem;
-    color: #5edb80;
-}
+.method-panel { display: none; animation: rise 0.2s ease; }
+.method-panel.active { display: block; }
 
-/* Info Box */
-.info-box {
-    background-color: rgba(13, 110, 253, 0.1);
-    border: 2px solid #0d6efd;
-    border-radius: 8px;
-    padding: 1rem;
-    margin-top: 1rem;
-    color: #6cb2f7;
-}
+/* ---------- Flash hero ---------- */
 
-/* Troubleshooting */
-.troubleshooting {
-    background-color: #383838;
-    border-radius: 12px;
+.flash-hero {
+    position: relative;
+    background: var(--panel);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
     padding: 1.5rem;
-    margin-top: 2rem;
-    border: 1px solid #484848;
+    margin-bottom: 1rem;
 }
 
-.troubleshooting h3 {
-    margin-top: 0;
-    color: #ffc107;
+/* Punched-tape strip along the top edge */
+.flash-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    border-radius: var(--radius) var(--radius) 0 0;
+    background:
+        repeating-linear-gradient(90deg,
+            var(--amber-deep) 0 14px, transparent 14px 20px,
+            var(--amber-deep) 20px 24px, transparent 24px 30px);
+    opacity: 0.8;
 }
+
+.flash-hero-text {
+    color: var(--text-dim);
+    font-size: 0.96rem;
+    margin: 0 0 1.1rem;
+    max-width: 58ch;
+}
+
+.btn-hero {
+    display: inline-block;
+    font-family: var(--display);
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #1c1204;
+    background: linear-gradient(180deg, var(--amber-bright), var(--amber));
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 0.8rem 1.9rem;
+    cursor: pointer;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.4),
+        0 3px 0 var(--amber-deep),
+        0 6px 16px rgba(240, 166, 60, 0.25);
+    transition: transform 0.1s ease, box-shadow 0.1s ease, filter 0.15s ease;
+}
+
+.btn-hero:hover:not(:disabled) { filter: brightness(1.06); }
+
+.btn-hero:active:not(:disabled) {
+    transform: translateY(2px);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.4),
+        0 1px 0 var(--amber-deep),
+        0 3px 8px rgba(240, 166, 60, 0.2);
+}
+
+.btn-hero:disabled { opacity: 0.55; cursor: default; }
+
+.btn-hero.attention { animation: keypulse 1.6s ease-in-out infinite; }
+
+@keyframes keypulse {
+    0%, 100% { box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), 0 3px 0 var(--amber-deep), 0 0 0 0 rgba(240, 166, 60, 0.5); }
+    50% { box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), 0 3px 0 var(--amber-deep), 0 0 0 10px rgba(240, 166, 60, 0); }
+}
+
+.flash-hint {
+    margin-top: 0.9rem;
+    padding: 0.6rem 0.8rem;
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.35);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius-sm);
+    color: var(--amber-bright);
+    font-size: 0.9rem;
+}
+
+.flash-hint.ok {
+    background: var(--green-soft);
+    border-color: rgba(143, 202, 111, 0.4);
+    border-left-color: var(--green);
+    color: var(--green);
+}
+
+/* Timeline: indicator lamps on a dashed line */
+
+.flash-timeline {
+    list-style: none;
+    margin: 1.35rem 0 0;
+    padding: 0;
+}
+
+.flash-timeline li {
+    position: relative;
+    padding: 0.35rem 0 0.35rem 1.9rem;
+    color: var(--muted);
+    font-size: 0.93rem;
+    font-family: var(--mono);
+    letter-spacing: 0.01em;
+    transition: color 0.2s ease;
+}
+
+.flash-timeline li::before {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 1.6rem;
+    bottom: -0.35rem;
+    width: 0;
+    border-left: 2px dashed var(--border-strong);
+}
+
+.flash-timeline li:last-child::before { display: none; }
+
+.tl-dot {
+    position: absolute;
+    left: 1px;
+    top: 0.68rem;
+    width: 13px;
+    height: 13px;
+    border-radius: 3px;
+    border: 2px solid var(--border-strong);
+    background: var(--panel-2);
+    transition: all 0.2s ease;
+}
+
+.flash-timeline li.active { color: var(--amber-bright); font-weight: 600; }
+.flash-timeline li.active .tl-dot {
+    border-color: var(--amber);
+    background: var(--amber-soft);
+    box-shadow: 0 0 10px rgba(240, 166, 60, 0.6);
+    animation: lampblink 1s steps(1) infinite;
+}
+
+@keyframes lampblink {
+    0%, 55% { background: var(--amber); }
+    60%, 100% { background: var(--amber-soft); }
+}
+
+.flash-timeline li.done { color: var(--text-dim); }
+.flash-timeline li.done .tl-dot {
+    border-color: var(--green);
+    background: var(--green);
+    box-shadow: 0 0 6px rgba(143, 202, 111, 0.5);
+}
+
+.flash-timeline li.error { color: var(--red); font-weight: 600; }
+.flash-timeline li.error .tl-dot { border-color: var(--red); background: var(--red-soft); }
+
+/* Progress: morse tape */
+
+.progress-track {
+    margin-top: 0.5rem;
+    height: 10px;
+    background: #0e0c08;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    width: 0%;
+    background:
+        repeating-linear-gradient(90deg,
+            var(--amber) 0 12px, rgba(240, 166, 60, 0.25) 12px 16px,
+            var(--amber) 16px 19px, rgba(240, 166, 60, 0.25) 19px 23px);
+    transition: width 0.2s ease;
+}
+
+.progress-container { margin-top: 1.1rem; }
+.progress-label { font-family: var(--mono); font-size: 0.85rem; color: var(--text-dim); margin-bottom: 0.4rem; }
+.progress-percent { margin-top: 0.4rem; font-family: var(--mono); font-size: 0.8rem; color: var(--muted); }
+
+/* Result banner */
+
+.flash-result {
+    margin-top: 1.1rem;
+    padding: 0.9rem 1.1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    line-height: 1.55;
+}
+
+.flash-result.ok {
+    background: var(--green-soft);
+    border: 1px solid rgba(143, 202, 111, 0.4);
+    border-left: 3px solid var(--green);
+    color: var(--text);
+}
+
+.flash-result.err {
+    background: var(--red-soft);
+    border: 1px solid rgba(238, 108, 90, 0.4);
+    border-left: 3px solid var(--red);
+    color: var(--text);
+}
+
+.flash-result a { color: var(--amber-bright); font-weight: 600; }
+
+/* ---------- Advanced / collapsibles ---------- */
 
 details {
-    background-color: #2c2c2c;
-    border-radius: 6px;
-    padding: 1rem;
-    margin-bottom: 1rem;
-    border: 1px solid #484848;
+    background: var(--panel);
+    border-radius: var(--radius);
+    padding: 0.7rem 1rem;
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--border);
 }
 
 summary {
     cursor: pointer;
-    font-weight: 500;
-    color: #6cb2f7;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--text-dim);
     user-select: none;
 }
 
-summary:hover {
-    color: #8ec5ff;
+summary:hover { color: var(--amber-bright); }
+
+details[open] > summary { margin-bottom: 0.75rem; }
+
+details p, details ul { margin: 0.5rem 0; }
+
+.advanced { margin-top: 0.25rem; }
+
+.advanced > summary {
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
 }
 
-details[open] summary {
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid #484848;
-}
+.advanced-body { font-size: 0.92rem; color: var(--text-dim); }
 
-details p, details ul {
-    margin: 0.5rem 0;
-}
+.advanced-note { color: var(--muted); font-size: 0.88rem; margin: 0.25rem 0 0.75rem; }
 
-/* What's New Section */
-.whats-new {
-    background-color: #383838;
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    margin-bottom: 1.5rem;
-    border: 1px solid #484848;
-}
-
-.whats-new summary {
-    font-weight: 500;
-    font-size: 0.95rem;
-    color: #aaa;
+.advanced-actions {
     display: flex;
-    align-items: center;
+    flex-wrap: wrap;
     gap: 0.5rem;
-    cursor: pointer;
-    list-style: none; /* Remove default arrow */
-}
-
-.whats-new summary::-webkit-details-marker {
-    display: none; /* Remove default arrow in webkit browsers */
-}
-
-.whats-new summary:hover {
-    color: #e0e0e0;
-}
-
-.expand-icon {
-    font-size: 0.7rem;
-    transition: transform 0.3s ease;
-    color: #6cb2f7;
-}
-
-.whats-new[open] .expand-icon {
-    transform: rotate(90deg);
-}
-
-.click-hint {
-    font-size: 0.8rem;
-    color: #888;
-    font-weight: normal;
-    font-style: italic;
-    margin-left: auto;
-}
-
-.whats-new[open] summary {
-    color: #6cb2f7;
     margin-bottom: 0.75rem;
-    padding-bottom: 0.5rem;
 }
 
-.whats-new ul {
-    margin: 0.5rem 0 0.5rem 1.5rem;
+.advanced-tips {
+    margin: 0.5rem 0;
+    padding-left: 1.1rem;
+    color: var(--muted);
+    font-size: 0.88rem;
+}
+
+.advanced-tips li { margin-bottom: 0.45rem; }
+
+.log-details { background: transparent; border-style: dashed; }
+
+.log-pre, #serialLog, #espFlashLog, #serialFlashLog {
+    background: #0c0a07;
+    color: #c8ba9a;
+    border: 1px solid var(--border);
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    max-height: 260px;
+    min-height: 60px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    margin: 0;
+}
+
+/* ---------- UF2 steps ---------- */
+
+.uf2-steps {
+    list-style: none;
+    counter-reset: uf2;
+    margin: 0 0 1rem;
     padding: 0;
 }
 
-.whats-new li {
-    font-size: 0.9rem;
-    margin-bottom: 0.4rem;
-    color: #ccc;
-}
-
-/* Scrollable container so long release notes never get silently cut off */
-.whats-new-scroll {
-    max-height: 260px;
-    overflow-y: auto;
-}
-
-.whats-new-scroll::-webkit-scrollbar {
-    width: 8px;
-}
-
-.whats-new-scroll::-webkit-scrollbar-thumb {
-    background: #555;
-    border-radius: 4px;
-}
-
-.manual-link {
-    font-size: 0.85rem;
-    margin: 0.5rem 0 0 0;
-}
-
-code {
-    background-color: #1a1a1a;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-family: 'Courier New', monospace;
-    color: #ffc107;
-}
-
-/* Button Group for ESP Flasher */
-.button-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-}
-
-.button-group button {
-    flex: 1;
-    min-width: 200px;
-}
-
-/* Highlight animation for suggested buttons */
-.highlight-button {
-    animation: highlightPulse 2s ease-in-out infinite;
-    box-shadow: 0 0 20px rgba(255, 193, 7, 0.5);
-}
-
-@keyframes highlightPulse {
-    0%, 100% {
-        box-shadow: 0 0 10px rgba(255, 193, 7, 0.3);
-        border-color: #ffc107;
-    }
-    50% {
-        box-shadow: 0 0 25px rgba(255, 193, 7, 0.6);
-        border-color: #ffda6a;
-    }
-}
-
-/* Warning button variant */
-.btn-warning {
-    display: inline-block;
-    padding: 12px 28px;
-    font-size: 1rem;
-    font-weight: 500;
-    border: 2px solid #ffc107;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    background-color: rgba(255, 193, 7, 0.15);
-    color: #ffc107;
-}
-
-.btn-warning:hover {
-    background-color: rgba(255, 193, 7, 0.25);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 193, 7, 0.3);
-}
-
-/* Manual bootloader callout box */
-.manual-bootloader-callout {
-    background: linear-gradient(135deg, #3d2a00 0%, #4a3500 100%);
-    border: 2px solid #ffc107;
-    border-radius: 12px;
-    padding: 1.5rem;
-    margin: 1.5rem 0;
-}
-
-.manual-bootloader-callout h4 {
-    color: #ffc107;
-    margin-top: 0;
-    margin-bottom: 1rem;
-    font-size: 1.1rem;
-}
-
-.manual-bootloader-callout ol {
-    margin: 0;
-    padding-left: 1.5rem;
-}
-
-.manual-bootloader-callout li {
+.uf2-steps > li {
+    counter-increment: uf2;
+    position: relative;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.15rem 1rem 3.2rem;
     margin-bottom: 0.75rem;
-    color: #e0e0e0;
 }
 
-.manual-bootloader-callout strong {
-    color: #ffda6a;
+.uf2-steps > li::before {
+    content: counter(uf2, decimal-leading-zero);
+    position: absolute;
+    left: 0.9rem;
+    top: 1.05rem;
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--amber);
 }
 
-/* Firmware version badge */
-.firmware-version {
+.uf2-step-title { font-family: var(--display); font-weight: 600; color: var(--text); margin-bottom: 0.3rem; letter-spacing: 0.02em; }
+
+.uf2-steps p { color: var(--muted); font-size: 0.9rem; margin: 0.25rem 0 0.75rem; }
+
+/* ---------- Buttons ---------- */
+
+.btn-primary, .btn-secondary, .btn-download, .btn-warning, .btn-ghost {
+    display: inline-block;
+    font-family: var(--mono);
+    padding: 0.55rem 1.2rem;
     font-size: 0.85rem;
     font-weight: 600;
-    background: linear-gradient(135deg, #2d5a2d 0%, #1e3d1e 100%);
-    color: #7fff7f;
-    padding: 0.25em 0.6em;
-    border-radius: 6px;
-    border: 1px solid #4a9f4a;
-    vertical-align: middle;
+    letter-spacing: 0.04em;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, filter 0.15s ease;
+    text-decoration: none;
+    text-align: center;
 }
 
-.firmware-version.test-version {
-    background: linear-gradient(135deg, #5a4a2d 0%, #3d351e 100%);
-    color: #ffc107;
-    border-color: #8a7a3a;
+.btn-primary {
+    background-color: var(--amber);
+    color: #1c1204;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 2px 0 var(--amber-deep);
 }
 
-/* Version Selector */
-.version-selector-container {
-    margin-top: 1rem;
+.btn-primary:hover { filter: brightness(1.07); }
+.btn-primary:active { transform: translateY(1px); box-shadow: inset 0 1px 0 rgba(255,255,255,0.3), 0 1px 0 var(--amber-deep); }
+
+.btn-secondary {
+    background-color: transparent;
+    color: var(--text-dim);
+    border-color: var(--border-strong);
 }
 
-.version-selector-row {
-    display: flex;
+.btn-secondary:hover { background-color: var(--panel-2); color: var(--text); border-color: var(--amber-deep); }
+
+.btn-secondary.danger { border-color: rgba(238, 108, 90, 0.5); color: var(--red); }
+
+.btn-ghost { background: transparent; color: var(--muted); border-color: transparent; }
+.btn-ghost:hover { color: var(--text); background: var(--panel-2); }
+
+.btn-sm { padding: 0.38rem 0.85rem; font-size: 0.78rem; }
+
+.btn-download {
+    background: var(--green);
+    color: #0d1408;
+    font-weight: 700;
+    display: inline-flex;
     align-items: center;
-    gap: 1.5rem;
-    flex-wrap: wrap;
+    gap: 0.5rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 2px 0 #4a7a35;
 }
+
+.btn-download:hover { filter: brightness(1.07); text-decoration: none; }
+
+.btn-download.disabled {
+    background: var(--panel-3);
+    color: var(--muted);
+    cursor: not-allowed;
+    filter: none;
+    box-shadow: none;
+}
+
+.download-icon { font-size: 1rem; }
+
+.btn-warning {
+    border-color: var(--amber);
+    background: var(--amber-soft);
+    color: var(--amber-bright);
+}
+
+.btn-warning:hover { background: rgba(240, 166, 60, 0.22); }
+
+.btn-compact { padding: 5px 12px !important; font-size: 0.78rem !important; margin: 0 !important; }
+
+.linklike {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: var(--amber-bright);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+/* ---------- Version selector ---------- */
 
 .version-select {
     flex: 1;
-    min-width: 250px;
-    padding: 10px 14px;
-    font-size: 1rem;
-    background-color: #2c2c2c;
-    color: #e0e0e0;
-    border: 2px solid #484848;
-    border-radius: 8px;
+    min-width: 220px;
+    padding: 0.5rem 2.2rem 0.5rem 0.75rem;
+    font-size: 0.88rem;
+    font-family: var(--mono);
+    background-color: var(--panel-2);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: border-color 0.3s ease;
+    transition: border-color 0.15s ease;
     appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23888' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23f0a63c' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
-    padding-right: 36px;
 }
 
-.version-select:hover,
-.version-select:focus {
-    border-color: #0d6efd;
-    outline: none;
-}
+.version-select:hover, .version-select:focus { border-color: var(--amber); outline: none; }
+.version-select:disabled { opacity: 0.5; cursor: wait; }
+.version-select option { background-color: var(--panel-2); color: var(--text); }
 
-.version-select:disabled {
-    opacity: 0.5;
-    cursor: wait;
-}
+.test-release-option { color: var(--amber-bright) !important; }
 
-.version-select option {
-    background-color: #2c2c2c;
-    color: #e0e0e0;
-    padding: 8px;
-}
-
-.test-release-option {
-    color: #ffc107 !important;
-}
-
-/* Test Release Toggle */
 .test-release-toggle {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.45rem;
     cursor: pointer;
     white-space: nowrap;
     user-select: none;
 }
 
 .test-release-toggle input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: #ffc107;
+    width: 15px;
+    height: 15px;
+    accent-color: var(--amber);
     cursor: pointer;
 }
 
-.toggle-label {
-    font-size: 0.95rem;
-    color: #aaa;
-    transition: color 0.2s;
-}
+.toggle-label { font-family: var(--mono); font-size: 0.78rem; letter-spacing: 0.04em; color: var(--muted); transition: color 0.15s; }
+.test-release-toggle:hover .toggle-label { color: var(--text); }
 
-.test-release-toggle:hover .toggle-label {
-    color: #e0e0e0;
-}
-
-/* Test Release Warning */
 .test-release-warning {
     margin-top: 0.75rem;
-    padding: 0.75rem 1rem;
-    background-color: rgba(255, 193, 7, 0.1);
-    border: 1px solid rgba(255, 193, 7, 0.4);
-    border-radius: 8px;
-    color: #ffda6a;
-    font-size: 0.9rem;
+    padding: 0.6rem 0.85rem;
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.4);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius-sm);
+    color: var(--amber-bright);
+    font-size: 0.88rem;
     line-height: 1.5;
 }
 
-/* Release Info Panel */
-.release-info {
-    margin-top: 1rem;
-    padding: 1rem 1.25rem;
-    background-color: #2c2c2c;
-    border: 1px solid #484848;
-    border-radius: 8px;
+.release-notes-details {
+    margin: 0.75rem 0 0;
+    background: var(--panel-2);
+    border-color: var(--border);
 }
 
-.release-info-header {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid #3a3a3a;
-}
+.release-date { font-family: var(--mono); font-size: 0.75rem; color: var(--muted); font-weight: 400; margin-left: 0.4rem; }
 
-.release-date {
-    font-size: 0.9rem;
-    color: #888;
-}
-
-/* Release Notes */
 .release-notes {
-    font-size: 0.9rem;
-    color: #ccc;
-    line-height: 1.6;
-    max-height: 300px;
+    font-size: 0.88rem;
+    color: var(--text-dim);
+    line-height: 1.55;
+    max-height: 260px;
     overflow-y: auto;
 }
 
-.release-notes h3 {
-    font-size: 1.1rem;
-    color: #6cb2f7;
-    margin: 1rem 0 0.5rem;
+.release-notes ul { margin: 0.3rem 0 0.5rem 1.1rem; padding: 0; }
+.release-notes li { margin-bottom: 0.3rem; }
+.release-notes li.note-heading { list-style: none; margin-left: -1.1rem; font-weight: 650; color: var(--text); margin-top: 0.5rem; }
+.release-notes strong { color: var(--text); }
+.no-notes { color: var(--muted); font-style: italic; }
+
+.firmware-version {
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: var(--green-soft);
+    color: var(--green);
+    padding: 0.2em 0.6em;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(143, 202, 111, 0.4);
+    vertical-align: middle;
 }
 
-.release-notes h3:first-child {
-    margin-top: 0;
+.firmware-version.test-version {
+    background: var(--amber-soft);
+    color: var(--amber-bright);
+    border-color: rgba(240, 166, 60, 0.4);
 }
 
-.release-notes h4 {
-    font-size: 1rem;
-    color: #aaa;
-    margin: 0.75rem 0 0.4rem;
+/* ---------- Notices ---------- */
+
+.no-webserial {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.4);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius-sm);
+    color: var(--amber-bright);
+    font-size: 0.92rem;
 }
 
-.release-notes ul {
-    margin: 0.4rem 0 0.75rem 1.25rem;
-    padding: 0;
+.success-message {
+    background: var(--green-soft);
+    border: 1px solid rgba(143, 202, 111, 0.35);
+    border-left: 3px solid var(--green);
+    border-radius: var(--radius-sm);
+    padding: 0.8rem 1rem;
+    margin-top: 0.75rem;
+    color: var(--text-dim);
+    font-size: 0.93rem;
 }
 
-.release-notes li {
-    margin-bottom: 0.3rem;
+.success-message.subtle { margin: 0.75rem 0 1rem; }
+.success-message a { color: var(--green); font-weight: 600; }
+.success-message strong { color: var(--text); }
+
+.info-box {
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.35);
+    border-radius: var(--radius-sm);
+    padding: 0.9rem 1rem;
+    margin: 1rem 0;
+    color: var(--amber-bright);
 }
 
-.release-notes p {
-    margin: 0.5rem 0;
+.warning-box {
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.4);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius-sm);
+    padding: 0.9rem 1rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.92rem;
+    color: var(--text-dim);
 }
 
-.release-notes strong {
-    color: #e0e0e0;
+/* Legacy troubleshooting block */
+.troubleshooting {
+    background: var(--panel);
+    border-radius: var(--radius);
+    padding: 1.15rem 1.25rem;
+    margin-top: 1.5rem;
+    border: 1px solid var(--border);
 }
 
-.release-notes code {
-    background-color: #1a1a1a;
-    padding: 1px 5px;
-    border-radius: 3px;
-    font-size: 0.85em;
+.troubleshooting h3 { margin-top: 0; color: var(--amber-bright); font-family: var(--display); }
+.troubleshooting details { background: var(--panel-2); }
+
+/* ---------- What's New ---------- */
+
+.whats-new {
+    background: var(--panel);
+    border-radius: var(--radius);
+    padding: 0.6rem 0.9rem;
+    margin-bottom: 1.1rem;
+    border: 1px solid var(--border);
 }
 
-.no-notes {
-    color: #666;
-    font-style: italic;
+.whats-new summary {
+    font-weight: 500;
+    font-size: 0.88rem;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    list-style: none;
 }
 
-/* Lists */
-ol, ul {
-    padding-left: 1.5rem;
+.whats-new summary::-webkit-details-marker { display: none; }
+.whats-new summary:hover { color: var(--text); }
+.whats-new summary strong { color: var(--text-dim); }
+
+.expand-icon { font-size: 0.55rem; transition: transform 0.2s ease; color: var(--amber); }
+.whats-new[open] .expand-icon { transform: rotate(90deg); }
+
+.click-hint {
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--amber);
+    font-weight: 600;
+    margin-left: auto;
+    background: var(--amber-soft);
+    padding: 0.12rem 0.55rem;
+    border-radius: var(--radius-sm);
 }
 
-ol li, ul li {
+.whats-new ul { margin: 0.4rem 0 0.4rem 1.25rem; padding: 0; }
+.whats-new li { font-size: 0.87rem; margin-bottom: 0.35rem; color: var(--text-dim); }
+.whats-new li.note-heading { list-style: none; margin-left: -1.25rem; font-weight: 650; color: var(--text); margin-top: 0.4rem; }
+
+.whats-new-scroll { max-height: 240px; overflow-y: auto; }
+.whats-new-scroll::-webkit-scrollbar { width: 8px; }
+.whats-new-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 4px; }
+
+.manual-link { font-size: 0.85rem; margin: 0.5rem 0 0 0; }
+
+/* ---------- ESP buttons row ---------- */
+
+.esp-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    align-items: center;
+}
+
+.manual-bootloader-instructions {
+    background: var(--panel-2);
+    border-radius: var(--radius-sm);
+    padding: 0.9rem 1rem;
     margin-bottom: 0.75rem;
 }
 
-/* Links */
-a {
-    color: #6cb2f7;
-    text-decoration: none;
+.manual-bootloader-instructions ol { margin: 0.5rem 0 0.9rem; padding-left: 1.3rem; }
+.manual-bootloader-instructions li { margin-bottom: 0.35rem; color: var(--text-dim); font-size: 0.9rem; }
+
+/* ---------- Misc / legacy ---------- */
+
+code {
+    background: #0c0a07;
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    font-family: var(--mono);
+    font-size: 0.85em;
+    color: var(--amber-bright);
 }
 
-a:hover {
-    text-decoration: underline;
-}
+ol, ul { padding-left: 1.4rem; }
+ol li, ul li { margin-bottom: 0.5rem; }
 
-/* Navigation Bar */
-nav {
-    background-color: #1a1a1a;
-    padding: 1rem 0;
-    text-align: center;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-}
+a { color: var(--amber-bright); text-decoration: none; }
+a:hover { text-decoration: underline; }
 
-nav ul {
-    list-style-type: none;
+.log-container { margin-top: 0.75rem; }
+.log-container h4 { font-size: 0.85rem; margin-bottom: 0.4rem; color: var(--muted); }
+
+#debugLog {
+    background: #0c0a07 !important;
+    color: #c8ba9a !important;
+    border: 1px solid var(--border) !important;
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    height: 340px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: var(--mono);
+    font-size: 0.78rem;
     margin: 0;
-    padding: 0;
 }
 
-nav ul li {
-    display: inline;
-    margin: 0 1rem;
-}
-
-nav ul li a {
-    color: white;
-    text-decoration: none;
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    transition: background-color 0.3s ease;
-}
-
-nav ul li a:hover {
-    background-color: #333;
-    text-decoration: none;
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-    .container {
-        width: 95%;
-        padding: 1.5rem;
-        margin: 1rem auto;
-    }
-
-    h1 {
-        font-size: 2rem;
-    }
-
-    h2 {
-        font-size: 1.5rem;
-    }
-
-    .progress-bar {
-        padding: 0;
-    }
-
-    .progress-line {
-        width: 50px;
-        margin: 0 0.5rem;
-    }
-
-    .step-number {
-        width: 40px;
-        height: 40px;
-        font-size: 1rem;
-    }
-
-    .step-label {
-        font-size: 0.8rem;
-    }
-
-    .card-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .boot-methods {
-        grid-template-columns: 1fr;
-    }
-
-    .btn-primary, .btn-secondary, .btn-download {
-        width: 100%;
-        margin-bottom: 0.5rem;
-    }
-
-    .btn-secondary {
-        margin-right: 0;
-    }
-
-    .version-selector-row {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 0.75rem;
-    }
-
-    .version-select {
-        min-width: unset;
-    }
-}
-
-@media (max-width: 480px) {
-    h1 {
-        font-size: 1.6rem;
-    }
-
-    .step-label {
-        display: none;
-    }
-
-    .progress-line {
-        width: 30px;
-    }
-
-    .container {
-        padding: 1rem;
-    }
-
-    .flash-step {
-        padding: 1rem;
-    }
-}
-
-/* ---- Troubleshooting Recorder (troubleshoot.html) ---- */
 .info-note {
-    background: rgba(108, 178, 247, 0.08);
-    border: 1px solid rgba(108, 178, 247, 0.35);
-    border-left: 4px solid #6cb2f7;
-    border-radius: 8px;
-    padding: 14px 16px;
-    margin: 1.5rem 0;
-    color: #cfe3fb;
-    font-size: 0.95rem;
+    background: var(--amber-soft);
+    border: 1px solid rgba(240, 166, 60, 0.35);
+    border-left: 3px solid var(--amber);
+    border-radius: var(--radius-sm);
+    padding: 0.85rem 1rem;
+    margin: 1.25rem 0;
+    color: var(--text-dim);
+    font-size: 0.92rem;
 }
-.info-note a { color: #9ccbfb; }
 
-.muted {
-    color: #999;
-    font-weight: 400;
-    font-size: 0.9em;
-}
+.info-note a { color: var(--amber-bright); }
+
+.muted { color: var(--muted); font-weight: 400; font-size: 0.9em; }
 
 .debug-controls {
     display: flex;
@@ -959,13 +1168,10 @@ nav ul li a:hover {
     margin-top: 12px;
 }
 
-.conn-status {
-    font-size: 0.9rem;
-    color: #bbb;
-}
-.conn-status.ok   { color: #6fcf97; }
-.conn-status.err  { color: #ff8a80; }
-.conn-status.wait { color: #ffc107; font-weight: 600; }
+.conn-status { font-family: var(--mono); font-size: 0.82rem; color: var(--muted); }
+.conn-status.ok { color: var(--green); }
+.conn-status.err { color: var(--red); }
+.conn-status.wait { color: var(--amber-bright); font-weight: 600; }
 
 .debug-toolbar {
     display: flex;
@@ -975,23 +1181,34 @@ nav ul li a:hover {
     margin: 12px 0 8px;
 }
 
-.btn-compact {
-    padding: 6px 14px !important;
-    font-size: 0.85rem !important;
-    margin: 0 !important;
+/* Legacy button highlight (esp flasher) */
+.highlight-button { animation: keypulse 1.8s ease-in-out infinite; }
+
+/* Legacy blocks kept harmless for cached pages */
+.progress-bar, .boot-methods { display: block; }
+.boot-method {
+    background: var(--panel-2);
+    border-radius: var(--radius-sm);
+    padding: 1rem;
+    border: 1px solid var(--border);
 }
 
-#debugLog {
-    background-color: #1a1a1a !important;
-    color: #d0d0d0 !important;
-    border: 1px solid #444 !important;
-    padding: 1rem;
-    border-radius: 6px;
-    height: 340px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-family: 'Courier New', monospace;
-    font-size: 0.85rem;
-    margin: 0;
+/* ---------- Responsive ---------- */
+
+@media (max-width: 700px) {
+    .container { padding: 1.25rem 0.9rem 3rem; }
+    h1 { font-size: 1.4rem; }
+    h2 { font-size: 1.15rem; }
+    .nav-inner { flex-direction: column; gap: 0.15rem; padding-bottom: 0.4rem; }
+    .card-grid { grid-template-columns: 1fr; }
+    .flash-hero { padding: 1.15rem; }
+    .btn-hero { width: 100%; }
+    .esp-buttons button { width: 100%; }
+    .panel-row { align-items: stretch; flex-direction: column; gap: 0.6rem; }
+    .panel-row .test-release-toggle { align-self: flex-start; }
+    .resume-card { flex-direction: column; align-items: flex-start; }
+    .btn-primary, .btn-secondary, .btn-download, .btn-warning { width: 100%; }
+    .advanced-actions button, .resume-actions button { width: auto; }
+    .method-toggle { width: 100%; }
+    .method-tab { flex: 1; justify-content: center; padding: 0.6rem 0.5rem; }
 }

--- a/online-updater/troubleshoot.html
+++ b/online-updater/troubleshoot.html
@@ -7,8 +7,8 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=2026-07-04.3">
+    <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.5">
 </head>
 <body>
 <nav>

--- a/online-updater/troubleshoot.html
+++ b/online-updater/troubleshoot.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=2026-07-04.5">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.6">
 </head>
 <body>
 <nav>

--- a/online-updater/troubleshoot.html
+++ b/online-updater/troubleshoot.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vail Troubleshooting Recorder</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <link rel="stylesheet" href="style.css?v=2026-06-12.2">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css?v=2026-07-04.3">
 </head>
 <body>
 <nav>


### PR DESCRIPTION
Big cleanup of the updater tool.

## What changed

**Flashing is one click now.** The web flasher picks the COM port at most once, ever. It remembers granted devices, tells the running app apart from the bootloader by USB IDs, does the 1200 baud touch itself, and grabs the bootloader port automatically when it reappears. After the first flash on a machine, updates need zero pickers even if Windows moves the COM number around.

**No more board question.** The board inside is detected from the USB vendor id when a port gets picked (Seeed = XIAO, Adafruit = QT Py or Trinkey, Arduino = Micro), and the right firmware asset is chosen automatically. Fallbacks: a small two chip picker on the UF2 tab for browsers without WebSerial, and an inline ask for DIY clones with odd USB ids.

**Filtered port picker.** The browser popup only lists devices that could actually be the adapter, so no Bluetooth COM port noise. The full unfiltered list is still there under advanced options.

**One update screen.** Version picker, install from browser or download file toggle, status timeline with progress, advanced tools and logs collapsed. Arduino Micro uses the same flow with the AVR109 engine. Returning visitors can jump straight to their saved setup.

**New look.** Warm dark theme, amber controls, Courier Prime type. The troubleshoot page inherits it through the shared stylesheet.

Also fixes a null deref in esp-flasher.js that could make Summit bootloader entry report failure after it actually worked.

## Testing

Verified all wizard paths, both flash methods, micro and Vail Lite branches, the Summit screen, and mobile layout in a local preview. Not yet tested against real hardware, that's what this deploy is for. The erase test tool is still behind the #test hash for reproducing the stuck bootloader state.