### PR TITLE
Verify browser flashes before rebooting

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -327,7 +327,7 @@
 
 <script src="esp-flasher.js?v=2026-07-04.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="samba-flasher.js?v=2026-07-08.1"></script>
-<script src="script.js?v=2026-07-08.1" defer></script>
+<script src="samba-flasher.js?v=2026-07-08.2"></script>
+<script src="script.js?v=2026-07-08.2" defer></script>
 </body>
 </html>

--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -327,7 +327,7 @@
 
 <script src="esp-flasher.js?v=2026-07-04.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="samba-flasher.js?v=2026-06-13.5"></script>
-<script src="script.js?v=2026-07-04.4" defer></script>
+<script src="samba-flasher.js?v=2026-07-08.1"></script>
+<script src="script.js?v=2026-07-08.1" defer></script>
 </body>
 </html>

--- a/online-updater/samba-flasher.js
+++ b/online-updater/samba-flasher.js
@@ -12,6 +12,8 @@
 //   Y<sram>,0#              -> set SRAM source buffer, replies "Y\n\r"
 //   Y<flash>,<size>#        -> copy <size> bytes SRAM->flash, replies "Y\n\r"
 //   W<addr>,<value>#        -> write 32-bit word (used to reset via AIRCR)
+//   w<addr>,4#              -> read 32-bit word, replies 4 raw bytes (binary mode)
+//   Z<addr>,<size>#         -> CRC16 (XMODEM) of flash range, replies "Z<hex8>#\n\r"
 // All numbers are hex; every command ends with '#'.
 
 (function () {
@@ -25,6 +27,28 @@
     const AIRCR_RESET    = 0x05FA0004; // VECTKEY | SYSRESETREQ
 
     const hex8 = (n) => (n >>> 0).toString(16).toUpperCase().padStart(8, '0');
+
+    // CRC16 XMODEM (poly 0x1021, init 0) — the algorithm behind the monitor's
+    // Z command and bossac's verify pass.
+    const CRC16_TABLE = (() => {
+        const t = new Uint16Array(256);
+        for (let i = 0; i < 256; i++) {
+            let c = (i << 8) & 0xFFFF;
+            for (let j = 0; j < 8; j++) {
+                c = (c & 0x8000) ? (((c << 1) ^ 0x1021) & 0xFFFF) : ((c << 1) & 0xFFFF);
+            }
+            t[i] = c;
+        }
+        return t;
+    })();
+
+    function crc16(data) {
+        let crc = 0;
+        for (let i = 0; i < data.length; i++) {
+            crc = ((crc << 8) & 0xFFFF) ^ CRC16_TABLE[((crc >> 8) ^ data[i]) & 0xFF];
+        }
+        return crc;
+    }
 
     class SAMBAFlasher {
         constructor({ log, progress } = {}) {
@@ -148,6 +172,88 @@
             this.log(`Wrote ${total} bytes to flash.`);
         }
 
+        // Wait until at least `count` raw bytes are in the receive buffer, then
+        // consume and return them as byte values. Throws on timeout.
+        async _waitForBytes(count, timeoutMs = 3000) {
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                if (this.rx.length >= count) {
+                    const out = [];
+                    for (let i = 0; i < count; i++) out.push(this.rx.charCodeAt(i) & 0xFF);
+                    this.rx = this.rx.slice(count);
+                    return out;
+                }
+                await new Promise((r) => setTimeout(r, 15));
+            }
+            throw new Error(`Timed out reading ${count} bytes (got ${this.rx.length})`);
+        }
+
+        // Read one 32-bit word from the device. In binary mode the monitor
+        // replies with 4 raw little-endian bytes.
+        async readWord(addr) {
+            this.rx = '';
+            await this._sendStr(`w${hex8(addr)},4#`);
+            const b = await this._waitForBytes(4, 3000);
+            return (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 0;
+        }
+
+        // Ask the bootloader for the CRC16 of a flash range (Z command).
+        async crcRegion(addr, size) {
+            this.rx = '';
+            await this._sendStr(`Z${hex8(addr)},${hex8(size)}#`);
+            const reply = await this._waitFor('#', 20000);
+            const m = reply.match(/Z([0-9A-Fa-f]{8})#/);
+            if (!m) throw new Error(`Bad response to CRC check ("${reply.slice(-24).replace(/[\r\n]/g, '?')}")`);
+            return parseInt(m[1], 16) >>> 0;
+        }
+
+        // Compare a range of words against the local image. Returns the byte
+        // offsets that differ. Deterministic sample points: the vector table,
+        // the end of the image, and one word per KB in between.
+        async _sampleMismatches(bin, startAddr) {
+            const offsets = new Set([0, 4]);
+            for (let o = 0; o < bin.length; o += 1024) offsets.add(o);
+            offsets.add(bin.length - 4);
+            const bad = [];
+            for (const raw of [...offsets].sort((a, b) => a - b)) {
+                const off = raw & ~3;
+                if (off < 0 || off + 4 > bin.length) continue;
+                const dev = await this.readWord(startAddr + off);
+                const local = (bin[off] | (bin[off + 1] << 8) | (bin[off + 2] << 16) | (bin[off + 3] << 24)) >>> 0;
+                if (dev !== local) bad.push(off);
+            }
+            return bad;
+        }
+
+        // Verify what actually landed in flash, the step bossac always does and
+        // the reason a bad write there fails loudly instead of half-flashing a
+        // dead board. Prefers the Z CRC over the full image; falls back to (or
+        // double-checks with) sampled word reads. Throws on real mismatch.
+        async verifyFirmware(bin, startAddr = FLASH_APP_ADDR) {
+            this.log('Verifying flash contents…');
+            let crcMatch = null;
+            try {
+                const dev = await this.crcRegion(startAddr, bin.length);
+                crcMatch = ((dev & 0xFFFF) === crc16(bin));
+            } catch (_) {
+                this.log('CRC check unavailable on this bootloader, comparing sampled words instead.');
+            }
+            if (crcMatch === true) {
+                this.log('✅ Verification passed (CRC match over the full image).');
+                return;
+            }
+            // CRC missing or mismatched: adjudicate with direct word reads.
+            const bad = await this._sampleMismatches(bin, startAddr);
+            if (bad.length) {
+                throw new Error(`Verification FAILED: flash differs from the firmware image at ${bad.length} of the checked locations (first at offset 0x${bad[0].toString(16)}).`);
+            }
+            if (crcMatch === false) {
+                this.log('⚠️ CRC disagreed but every sampled word matches. Proceeding.');
+            } else {
+                this.log('✅ Verification passed (all sampled words match).');
+            }
+        }
+
         // Trigger a CPU reset so the freshly flashed app runs. The port drops as
         // the device re-enumerates, so a write error here is expected/benign.
         async resetDevice() {
@@ -165,6 +271,11 @@
         const view = new DataView(arrayBuffer);
         const blocks = [];
         let minAddr = Infinity, maxEnd = 0;
+        // Every UF2 block records its own index and the file's total block
+        // count, so a truncated or corrupted download is detectable instead of
+        // silently producing a partial image.
+        let expectedBlocks = null;
+        const seenBlocks = new Set();
         for (let pos = 0; pos + 512 <= arrayBuffer.byteLength; pos += 512) {
             const magic0 = view.getUint32(pos + 0, true);
             const magic1 = view.getUint32(pos + 4, true);
@@ -173,6 +284,10 @@
             const flags = view.getUint32(pos + 8, true);
             const addr = view.getUint32(pos + 12, true);
             const payloadSize = view.getUint32(pos + 16, true);
+            const blockNo = view.getUint32(pos + 20, true);
+            const numBlocks = view.getUint32(pos + 24, true);
+            if (expectedBlocks === null && numBlocks > 0) expectedBlocks = numBlocks;
+            seenBlocks.add(blockNo);
             if (flags & 0x00000001) continue; // "not main flash" block
             const data = new Uint8Array(arrayBuffer, pos + 32, payloadSize);
             blocks.push({ addr, data });
@@ -180,6 +295,9 @@
             if (addr + payloadSize > maxEnd) maxEnd = addr + payloadSize;
         }
         if (!blocks.length) throw new Error('No valid UF2 blocks found in firmware file.');
+        if (expectedBlocks !== null && seenBlocks.size !== expectedBlocks) {
+            throw new Error(`Firmware file is incomplete: found ${seenBlocks.size} of ${expectedBlocks} blocks. The download was likely cut short — try again.`);
+        }
         const bin = new Uint8Array(maxEnd - minAddr).fill(0xFF);
         for (const b of blocks) bin.set(b.data, b.addr - minAddr);
         return { bin, baseAddr: minAddr };

--- a/online-updater/samba-flasher.js
+++ b/online-updater/samba-flasher.js
@@ -51,9 +51,12 @@
     }
 
     class SAMBAFlasher {
-        constructor({ log, progress } = {}) {
+        constructor({ log, progress, chunkSize } = {}) {
             this.log = log || (() => {});
             this.progress = progress || (() => {});
+            // Per-transfer staging size. Smaller chunks are gentler on older
+            // factory bootloaders (Seeed XIAO); QT Py is proven at 4 KB.
+            this.chunkSize = chunkSize || CHUNK;
             this.port = null;
             this.reader = null;
             this.writer = null;
@@ -155,10 +158,14 @@
             const total = bin.length;
             let offset = 0;
             while (offset < total) {
-                const size = Math.min(CHUNK, total - offset);
+                const size = Math.min(this.chunkSize, total - offset);
                 const chunk = bin.subarray(offset, offset + size);
                 // 1) stage the chunk in SRAM
                 await this._sendStr(`S${hex8(SRAM_BUFFER)},${hex8(size)}#`);
+                // Give the monitor a beat to consume the command by itself.
+                // The bootloader's receive handler mis-assembles the staged
+                // data if command and payload ever land in one buffer read.
+                await new Promise((r) => setTimeout(r, 15));
                 await this._sendBytes(chunk);
                 // 2) point the source buffer at the staged data
                 await this._sendStr(`Y${hex8(SRAM_BUFFER)},0#`);

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -859,6 +859,9 @@ const flashEngine = {
         const flasher = new window.SAMBAFlasher({
             log: flashLog,
             progress: (cur, total) => flashUI.progress(cur, total),
+            // XIAO factory bootloaders are older builds, so stage in small
+            // conservative chunks there. QT Py is proven solid at the default.
+            chunkSize: wizardState.board === 'xiao' ? 512 : undefined,
         });
         try {
             await flasher.open(port);

--- a/online-updater/script.js
+++ b/online-updater/script.js
@@ -210,7 +210,9 @@ function getFirmwareFile() {
     const url = ext === 'hex'
         ? `${ADAPTER_FIRMWARE_PROXY}/vail-adapter/${adapterReleases.selected.tag_name}/${asset.name}`
         : asset.browser_download_url;
-    return { url, filename: asset.name, ext };
+    // size is the exact byte count GitHub reports for the asset, used to catch
+    // truncated downloads before anything touches the flash.
+    return { url, filename: asset.name, ext, size: asset.size || 0 };
 }
 
 // Friendly names
@@ -792,9 +794,19 @@ const flashEngine = {
         const resp = await fetch(proxyUrl, { cache: 'no-cache' });
         if (!resp.ok) throw new Error(`Firmware download failed (HTTP ${resp.status}). Check your connection and try again.`);
         if (firmware.ext === 'hex') {
-            return { kind: 'hex', text: await resp.text() };
+            const text = await resp.text();
+            if (firmware.size && text.length !== firmware.size) {
+                throw new Error(`Firmware download was incomplete (got ${text.length} of ${firmware.size} bytes). Try again.`);
+            }
+            return { kind: 'hex', text };
         }
-        const { bin, baseAddr } = window.uf2ToBin(await resp.arrayBuffer());
+        const buf = await resp.arrayBuffer();
+        // The GitHub release API told us exactly how big this asset is. If the
+        // proxy served anything else, stop before flash is ever touched.
+        if (firmware.size && buf.byteLength !== firmware.size) {
+            throw new Error(`Firmware download was incomplete (got ${buf.byteLength} of ${firmware.size} bytes). Try again.`);
+        }
+        const { bin, baseAddr } = window.uf2ToBin(buf);
         flashLog(`Firmware ready: ${bin.length} bytes @ 0x${baseAddr.toString(16)}.`);
         return { kind: 'bin', bin, baseAddr };
     },
@@ -851,8 +863,28 @@ const flashEngine = {
         try {
             await flasher.open(port);
             await flasher.connect();
-            await flasher.eraseApp();
-            await flasher.writeFirmware(fw.bin, fw.baseAddr);
+            // Write, then verify what actually landed in flash before letting
+            // the device reboot into it. One automatic rewrite on mismatch. If
+            // it still doesn't verify, do NOT reset: the device stays in
+            // bootloader mode, visible and recoverable, instead of rebooting
+            // into a half-written app that never enumerates.
+            for (let attempt = 1; ; attempt++) {
+                await flasher.eraseApp();
+                await flasher.writeFirmware(fw.bin, fw.baseAddr);
+                flashUI.hint('Double-checking the flash contents…');
+                try {
+                    await flasher.verifyFirmware(fw.bin, fw.baseAddr);
+                    flashUI.hint('');
+                    break;
+                } catch (err) {
+                    if (attempt >= 2) {
+                        flashUI.hint('');
+                        throw new Error(`${err.message} The adapter was left in bootloader mode, so it is still recoverable. Use the Download file method instead.`);
+                    }
+                    flashLog('Verification failed, erasing and writing again…');
+                    flashUI.progress(0, fw.bin.length);
+                }
+            }
             await flasher.resetDevice();
         } finally {
             try { await flasher.close(); } catch (_) {}


### PR DESCRIPTION
Someone flashed a brand new XIAO with install from browser and ended up with a board that looked dead, only the power led on. The write path never verified anything, so a corrupted image could pass the bootloader's app check and reboot into code that crashes before USB starts. Double tap reset recovers it since the bootloader is never touched, but that's a scary experience.

Went digging in the bootloader sources. The receive handler in the SAM-BA monitor mis-assembles staged data if the command and the first payload bytes ever land in one buffer read, and it acks everything anyway. QT Py boards ship a much newer bootloader build than factory XIAOs, which lines up with QT Py being flawless across ~200 web flashes while a XIAO got corrupted.

So this does three things:

- verifies. Downloaded file size gets checked against what the GitHub release says, UF2 block counts get checked so a cut short download errors out, and after writing the whole flash range gets CRC checked with the bootloader's Z command, same verify bossac runs. Falls back to reading sample words back if Z is missing. On a mismatch it erases and rewrites once, and if it fails again it stops WITHOUT resetting so the board stays in bootloader mode where its visible and easy to recover.
- paces. Short pause between the stage command and its payload so they never share a buffer read on old bootloaders.
- shrinks. XIAO writes go in 512 byte chunks since factory XIAOs run old bootloader builds. QT Py keeps the proven 4 KB.

Checked the CRC math against the standard test vector and the truncation check against a hand built partial uf2 locally. The failed XIAO from the field report is a perfect test unit, it should now either flash clean or fail loudly with a retry instead of playing dead.