### PR TITLE
Log the real bootloader version during serial flash

### DIFF
--- a/online-updater/index.html
+++ b/online-updater/index.html
@@ -327,7 +327,7 @@
 
 <script src="esp-flasher.js?v=2026-07-04.1" type="module"></script>
 <script src="avr109-flasher.js?v=2026-06-11.1"></script>
-<script src="samba-flasher.js?v=2026-07-08.2"></script>
+<script src="samba-flasher.js?v=2026-07-08.3"></script>
 <script src="script.js?v=2026-07-08.2" defer></script>
 </body>
 </html>

--- a/online-updater/samba-flasher.js
+++ b/online-updater/samba-flasher.js
@@ -123,9 +123,12 @@
                 await new Promise((r) => setTimeout(r, 120));
                 await this._sendStr('V#');           // request version
                 try {
-                    await this._waitFor('\n', 1200); // any newline = a line arrived
+                    // The version reply IS the first line (N# has no ack on
+                    // shipped bootloaders), so keep what _waitFor consumes.
+                    // The reply carries a stray NUL terminator — strip it.
+                    const line = await this._waitFor('\n', 1200);
                     await new Promise((r) => setTimeout(r, 150)); // let the rest land
-                    version = (this.rx || '').replace(/[\r\n]/g, ' ').trim();
+                    version = (line + this.rx).replace(/\0/g, '').replace(/[\r\n]/g, ' ').trim();
                 } catch (_) {
                     this.log(`No bootloader response yet (attempt ${attempt}/5)…`);
                 }


### PR DESCRIPTION
The connect handshake waited for a newline to know the version reply arrived, then threw away everything it consumed. Since N# has no ack on shipped bootloaders, that newline was the end of the version reply itself, so the log kept only an invisible NUL byte. Result: a blank Bootloader line and the bogus Arduino:XYZ warning on every single flash, including all the QT Py ones that work perfectly.

Now it keeps the line it consumed and strips the stray NUL the bootloader sends. The log shows the actual version string like v3.16.0 [Arduino:XYZ] and the warning only appears if a bootloader really doesnt advertise the extended commands. That version line is exactly what I want to see from XIAO field reports going forward.

Verified the parse against a simulated reply locally, no page errors.

## Summary by Sourcery

Improve bootloader version logging during SAM-BA serial flash by preserving and cleaning the version reply line.

Bug Fixes:
- Fix bootloader version parsing so the logged version string is correctly captured instead of appearing blank or malformed.

Enhancements:
- Strip stray NUL terminators from bootloader version replies to avoid bogus Arduino:XYZ warnings in logs.

Build:
- Bump samba-flasher.js cache-busting version in the updater HTML.